### PR TITLE
GenerateNetworkViewsTask overwrites style of views patch

### DIFF
--- a/core-task-impl/src/main/java/org/cytoscape/task/internal/loadnetwork/GenerateNetworkViewsTask.java
+++ b/core-task-impl/src/main/java/org/cytoscape/task/internal/loadnetwork/GenerateNetworkViewsTask.java
@@ -100,7 +100,6 @@ class GenerateNetworkViewsTask extends AbstractTask implements ObservableTask {
 				    // impossible.
                       		    vmm.setVisualStyle(style, view);
                 		}
-				vmm.setVisualStyle(style, view);
 				style.apply(view);
 				
 				if (!view.isSet(BasicVisualLexicon.NETWORK_CENTER_X_LOCATION)

--- a/core-task-impl/src/main/java/org/cytoscape/task/internal/loadnetwork/GenerateNetworkViewsTask.java
+++ b/core-task-impl/src/main/java/org/cytoscape/task/internal/loadnetwork/GenerateNetworkViewsTask.java
@@ -94,6 +94,12 @@ class GenerateNetworkViewsTask extends AbstractTask implements ObservableTask {
 			if (numGraphObjects < viewThreshold) {
 				final CyNetworkView view = viewReader.buildCyNetworkView(network);
 				networkViewManager.addNetworkView(view);
+				if ("default").equals(vmm.getVisualStyle(view).getTitle()){
+				    // Only set current style when no style, i.e. default, is set for view.
+				    // This allows the viewReader to set custom styles, which is currently
+				    // impossible.
+                      		    vmm.setVisualStyle(style, view);
+                		}
 				vmm.setVisualStyle(style, view);
 				style.apply(view);
 				


### PR DESCRIPTION
This should fix the problems with setting visual styles for NetworkReaders.
Normally one should be able to set a visual style in the buildNetworkView of the reader. 
Until now the currentView is always used to overwrite such custom styles.

NOT TESTED, NOT CHECKED. Some core developer please merge this and make it right.
