### PR TITLE
 "entrySet()" should be iterated when both the key and value are needed

### DIFF
--- a/app-impl/src/main/java/org/cytoscape/app/internal/ui/CurrentlyInstalledAppsPanel.java
+++ b/app-impl/src/main/java/org/cytoscape/app/internal/ui/CurrentlyInstalledAppsPanel.java
@@ -520,9 +520,9 @@ public class CurrentlyInstalledAppsPanel extends JPanel {
     	panel.add(title);
     	panel.add(Box.createVerticalStrut(title.getPreferredSize().height));
     	String deps = "";
-    	for(App app: otherAppsDependingOn.keySet()) {
-    		deps +=  app.getAppName() + " (required by";
-    		for(App otherAppDependingOn: otherAppsDependingOn.get(app)) {
+    	for(Map.Entry<App, Collection<App>> entry : otherAppsDependingOn.entrySet()) {
+    		deps += entry.getKey().getAppName() + " (required by";
+    		for(App otherAppDependingOn: entry.getValue()) {
     			deps += " " + otherAppDependingOn.getAppName() + ",";
     		}
     		deps = deps.substring(0, deps.length() - 1) + ")\n";

--- a/command-executor-impl/src/main/java/org/cytoscape/command/internal/CommandExecutorImpl.java
+++ b/command-executor-impl/src/main/java/org/cytoscape/command/internal/CommandExecutorImpl.java
@@ -204,18 +204,18 @@ public class CommandExecutorImpl {
 		Map<String, Object> modifiedSettings = new HashMap<String, Object>();
 		// Now check the arguments
 		List<String> argList = availableCommands.getArguments(ns, comm);
-		for (String inputArg: settings.keySet()) {
+		for (Map.Entry<String, Object> entry : settings.entrySet()) {
 			boolean found = false;
 			for (String arg: argList) {
 				String[] bareArg = arg.split("=");
-				if (bareArg[0].trim().equalsIgnoreCase(inputArg)) {
+				if (bareArg[0].trim().equalsIgnoreCase(entry.getKey())) {
 					found = true;
-					modifiedSettings.put(bareArg[0].trim(), settings.get(inputArg));
+					modifiedSettings.put(bareArg[0].trim(), entry.getValue());
 					break;
 				}
 			}	
 			if (!found)
-				throw new RuntimeException("Argument: '"+inputArg+" isn't applicable to command: '"+ns+" "+comm+"'");	
+				throw new RuntimeException("Argument: '"+ entry.getKey() +" isn't applicable to command: '"+ns+" "+comm+"'");	
 		}
 
 		executeCommand(ns, sub, modifiedSettings, tm, observer);

--- a/command-executor-impl/src/main/java/org/cytoscape/command/internal/tunables/CommandTunableInterceptorImpl.java
+++ b/command-executor-impl/src/main/java/org/cytoscape/command/internal/tunables/CommandTunableInterceptorImpl.java
@@ -75,9 +75,9 @@ public class CommandTunableInterceptorImpl extends AbstractTunableInterceptor<St
 					// information parsed from the arg string.
 					h.processArgString(args);
 				} else {
-					for ( String string: mapArgs.keySet() ) {
-						if (h.getName().equals(string)) {
-							Object v = mapArgs.get(string);
+					for (Map.Entry<String, Object> entry : mapArgs.entrySet()) {
+						if (h.getName().equals(entry.getKey())) {
+							Object v = entry.getValue();
 							try {
 								if (v instanceof String)
 									v = h.processArg((String)v);

--- a/core-task-impl/src/main/java/org/cytoscape/task/internal/hide/HideEdit.java
+++ b/core-task-impl/src/main/java/org/cytoscape/task/internal/hide/HideEdit.java
@@ -99,8 +99,8 @@ final class HideEdit extends AbstractCyEdit {
 
 	@Override
 	public void undo() {
-		for (final View<? extends CyIdentifiable> view : previousStates.keySet()) {
-			setVisible(view, previousStates.get(view));
+		for (final Map.Entry<View<? extends CyIdentifiable>, Boolean> entry : previousStates.entrySet()) {
+			setVisible(entry.getKey(), entry.getValue());
 		}
 		
 		updateNetworkView();

--- a/core-task-impl/src/main/java/org/cytoscape/task/internal/table/AbstractTableDataTask.java
+++ b/core-task-impl/src/main/java/org/cytoscape/task/internal/table/AbstractTableDataTask.java
@@ -73,10 +73,10 @@ public abstract class AbstractTableDataTask extends AbstractTask {
 
 		int count = 0;
 		CyRow row = table.getRow(id.getSUID());
-		for (CyColumn column: valueMap.keySet()) {
-			Class type = column.getType();
-				String name = column.getName();
-			Object value = valueMap.get(column);
+		for (Map.Entry<CyColumn, Object> entry : valueMap.entrySet()) {
+			Class type = entry.getKey().getType();
+				String name = entry.getKey().getName();
+			Object value = entry.getValue();
 			if (value != null) {
 				row.set(name, type.cast(value));
 				count++;

--- a/core-task-impl/src/main/java/org/cytoscape/task/internal/table/GetEdgeAttributeTask.java
+++ b/core-task-impl/src/main/java/org/cytoscape/task/internal/table/GetEdgeAttributeTask.java
@@ -78,9 +78,9 @@ public class GetEdgeAttributeTask extends AbstractTableDataTask implements Obser
 			edgeDataMap.put(edge, edgeData);
 
 			taskMonitor.showMessage(TaskMonitor.Level.INFO, "   Edge table values for edge "+DataUtils.getEdgeName(edgeTable, edge)+":");
-			for (String column: edgeData.keySet()) {
-				if (edgeData.get(column) != null)
-					taskMonitor.showMessage(TaskMonitor.Level.INFO, "        "+column+"="+DataUtils.convertData(edgeData.get(column)));
+			for (Map.Entry<String, Object> entry : edgeData.entrySet()) {
+				if (entry.getValue() != null)
+					taskMonitor.showMessage(TaskMonitor.Level.INFO, "        "+ entry.getKey() +"="+DataUtils.convertData(entry.getValue()));
 			}
 		}
 	}

--- a/core-task-impl/src/main/java/org/cytoscape/task/internal/table/GetNetworkAttributeTask.java
+++ b/core-task-impl/src/main/java/org/cytoscape/task/internal/table/GetNetworkAttributeTask.java
@@ -68,9 +68,9 @@ public class GetNetworkAttributeTask extends AbstractTableDataTask implements Ob
 		                                  columnTunable.getColumnNames(networkTable));
 
 		taskMonitor.showMessage(TaskMonitor.Level.INFO, "   Attribute values for network "+DataUtils.getNetworkTitle(network)+":");
-		for (String column: networkData.keySet()) {
-			if (networkData.get(column) != null)
-				taskMonitor.showMessage(TaskMonitor.Level.INFO, "        "+column+"="+DataUtils.convertData(networkData.get(column)));
+		for (Map.Entry<String, Object> entry : networkData.entrySet()) {
+			if (entry.getValue() != null)
+				taskMonitor.showMessage(TaskMonitor.Level.INFO, "        "+ entry.getKey() +"="+DataUtils.convertData(entry.getValue()));
 		}
 	}
 

--- a/core-task-impl/src/main/java/org/cytoscape/task/internal/table/GetNodeAttributeTask.java
+++ b/core-task-impl/src/main/java/org/cytoscape/task/internal/table/GetNodeAttributeTask.java
@@ -77,9 +77,9 @@ public class GetNodeAttributeTask extends AbstractTableDataTask implements Obser
 			nodeDataMap.put(node, nodeData);
 
 			taskMonitor.showMessage(TaskMonitor.Level.INFO, "   Node table values for node "+DataUtils.getNodeName(nodeTable, node)+":");
-			for (String column: nodeData.keySet()) {
-				if (nodeData.get(column) != null)
-					taskMonitor.showMessage(TaskMonitor.Level.INFO, "        "+column+"="+DataUtils.convertData(nodeData.get(column)));
+			for (Map.Entry<String, Object> entry : nodeData.entrySet()) {
+				if (entry.getValue() != null)
+					taskMonitor.showMessage(TaskMonitor.Level.INFO, "        "+ entry.getKey() +"="+DataUtils.convertData(entry.getValue()));
 			}
 		}
 	}

--- a/core-task-impl/src/main/java/org/cytoscape/task/internal/utils/DataUtils.java
+++ b/core-task-impl/src/main/java/org/cytoscape/task/internal/utils/DataUtils.java
@@ -93,10 +93,10 @@ public class DataUtils {
 			return "{}";
 
 		String result = "{";
-		for (Object key: data.keySet()) {
-			Object v = data.get(key);
+		for (Object o : data.entrySet()) {
+			Object v = ((Map.Entry) o).getValue();
 			if (v == null) continue;
-			result += key.toString()+":";
+			result += ((Map.Entry) o).getKey().toString()+":";
 			if (v instanceof List)
 				result += convertListToString((List)v)+",";
 			else if (v instanceof Map)

--- a/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/impl/cyannotator/CyAnnotator.java
+++ b/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/impl/cyannotator/CyAnnotator.java
@@ -225,11 +225,11 @@ public class CyAnnotator {
 
 			// Now, handle our Z-Order.  This needs to be done after everything else is
 			// added to make sure that we have the proper number of components
-			for (DingAnnotation a: zOrderMap.keySet()) {
-				if (a.getCanvas() != null)
-					a.getCanvas().setComponentZOrder(a.getComponent(), zOrderMap.get(a));
+			for (Map.Entry<DingAnnotation, Integer> entry : zOrderMap.entrySet()) {
+				if (entry.getKey().getCanvas() != null)
+					entry.getKey().getCanvas().setComponentZOrder(entry.getKey().getComponent(), entry.getValue());
 				else
-					foreGroundCanvas.setComponentZOrder(a.getComponent(), zOrderMap.get(a));
+					foreGroundCanvas.setComponentZOrder(entry.getKey().getComponent(), entry.getValue());
 			}
 
 		}
@@ -402,9 +402,9 @@ public class CyAnnotator {
 	private void updateNetworkAttributes(CyNetwork network) {
 		// Convert the annotation to a list
 		List<Map<String,String>> networkAnnotations = new ArrayList<Map<String, String>>();
-		for (DingAnnotation annotation: annotationMap.keySet()) {
+		for (Map.Entry<DingAnnotation, Map<String, String>> entry : annotationMap.entrySet()) {
 			if (view.getModel().equals(network))
-				networkAnnotations.add(annotationMap.get(annotation));
+				networkAnnotations.add(entry.getValue());
 		}
 		// Save it in the network attributes
 		List<String>networkAnnotation = convertAnnotationMap(networkAnnotations);
@@ -418,8 +418,8 @@ public class CyAnnotator {
 
 		for (Map<String,String> map: networkAnnotations) {
 			String entry = "";
-			for (String key: map.keySet()) {
-				entry += "|"+key+"="+map.get(key);
+			for (Map.Entry<String, String> mapEntry : map.entrySet()) {
+				entry += "|"+ mapEntry.getKey() +"="+ mapEntry.getValue();
 			}
 			result.add(entry.substring(1));
 		}

--- a/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/internal/charts/AbstractChartEditor.java
+++ b/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/internal/charts/AbstractChartEditor.java
@@ -1348,11 +1348,11 @@ public abstract class AbstractChartEditor<T extends AbstractCustomGraphics2<?>> 
 			selModel = new DefaultListModel<>();
 			
 			// Filter all columns that are list of numbers
-			for (final CyColumnIdentifier colId : columns.keySet()) {
-				final CyColumn c = columns.get(colId);
+			for (final Map.Entry<CyColumnIdentifier, CyColumn> entry : columns.entrySet()) {
+				final CyColumn c = entry.getValue();
 				
 				if (isDataColumn(c))
-					dataColumns.add(colId);
+					dataColumns.add(entry.getKey());
 			}
 			
 			final JLabel allColumnsLbl = new JLabel("Available Columns:");

--- a/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/internal/charts/box/BoxLayer.java
+++ b/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/internal/charts/box/BoxLayer.java
@@ -58,9 +58,9 @@ public class BoxLayer extends AbstractChartLayer<BoxAndWhiskerCategoryDataset> {
 	protected BoxAndWhiskerCategoryDataset createDataset() {
 		final DefaultBoxAndWhiskerCategoryDataset dataset = new DefaultBoxAndWhiskerCategoryDataset();
 		
-		for (String series : data.keySet()) {
-			final List<Double> values = data.get(series);
-			dataset.add(values, series, "1"); // switch series and category name so labels are displayed for series
+		for (Map.Entry<String, List<Double>> stringListEntry : data.entrySet()) {
+			final List<Double> values = stringListEntry.getValue();
+			dataset.add(values, stringListEntry.getKey(), "1"); // switch series and category name so labels are displayed for series
 		}
 		
 		return dataset;

--- a/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/graph/render/immed/GraphGraphics.java
+++ b/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/graph/render/immed/GraphGraphics.java
@@ -945,8 +945,8 @@ public final class GraphGraphics {
 	 */
 	public static Map<Byte, Shape> getArrowShapes() {
 		final Map<Byte, Shape> shapeMap = new HashMap<Byte, Shape>();
-		for (final Byte key : arrows.keySet()) {
-			shapeMap.put(key, arrows.get(key).getArrowShape() );
+		for (final Map.Entry<Byte, Arrow> entry : arrows.entrySet()) {
+			shapeMap.put(entry.getKey(), entry.getValue().getArrowShape() );
 		}
 		return shapeMap;
 	}

--- a/editor-impl/src/main/java/org/cytoscape/editor/internal/ClipboardImpl.java
+++ b/editor-impl/src/main/java/org/cytoscape/editor/internal/ClipboardImpl.java
@@ -209,13 +209,13 @@ public class ClipboardImpl {
 		double xOffset = xCenter - x;
 		double yOffset = yCenter - y;
 		
-		for (CyNode node : nodePositions.keySet()) {
-			final CyNode newNode = newNodeMap.get(node);
+		for (Entry<CyNode, double[]> cyNodeEntry : nodePositions.entrySet()) {
+			final CyNode newNode = newNodeMap.get(cyNodeEntry.getKey());
 			
 			if (newNode == null || !pastedObjects.contains(newNode))
 				continue;
 			
-			final double[] position = nodePositions.get(node);
+			final double[] position = cyNodeEntry.getValue();
 			double nodeX = (position == null ? 0 : position[0]) - xOffset;
 			double nodeY = (position == null ? 0 : position[1]) - yOffset;
 
@@ -225,7 +225,7 @@ public class ClipboardImpl {
 			if (newNodeView != null) {
 				newNodeView.setVisualProperty(BasicVisualLexicon.NODE_X_LOCATION, nodeX);
 				newNodeView.setVisualProperty(BasicVisualLexicon.NODE_Y_LOCATION, nodeY);
-				setLockedValues(newNodeView, node, nodeBypass);
+				setLockedValues(newNodeView, cyNodeEntry.getKey(), nodeBypass);
 			}
 		}
 		
@@ -412,27 +412,27 @@ public class ClipboardImpl {
 	private void copyRows(Map<CyRow,CyRow> rowMap) {
 		if (rowMap == null || rowMap.size() == 0) return;
 
-		for (CyRow sourceRow: rowMap.keySet()) {
-			CyRow targetRow = rowMap.get(sourceRow);
+		for (Entry<CyRow, CyRow> cyRowCyRowEntry : rowMap.entrySet()) {
+			CyRow targetRow = cyRowCyRowEntry.getValue();
 			CyTable destTable = targetRow.getTable();
-			CyTable sourceTable = sourceRow.getTable();
+			CyTable sourceTable = cyRowCyRowEntry.getKey().getTable();
 
 			Map<String, Object> oldDataMap;
-			if (oldValueMap.containsKey(sourceRow))
-				oldDataMap = oldValueMap.get(sourceRow);
+			if (oldValueMap.containsKey(cyRowCyRowEntry.getKey()))
+				oldDataMap = oldValueMap.get(cyRowCyRowEntry.getKey());
 			else
-				oldDataMap = sourceRow.getAllValues();
+				oldDataMap = cyRowCyRowEntry.getKey().getAllValues();
 
-			for (String colName: oldDataMap.keySet()) {
-				CyColumn column = destTable.getColumn(colName);
+			for (Entry<String, Object> stringObjectEntry : oldDataMap.entrySet()) {
+				CyColumn column = destTable.getColumn(stringObjectEntry.getKey());
 
 				if (column == null) {
-					CyColumn sourceColumn = sourceTable.getColumn(colName);
+					CyColumn sourceColumn = sourceTable.getColumn(stringObjectEntry.getKey());
 					if (sourceColumn.getType() == List.class) {
-						destTable.createListColumn(colName, sourceColumn.getListElementType(), 
+						destTable.createListColumn(stringObjectEntry.getKey(), sourceColumn.getListElementType(), 
 						                           sourceColumn.isImmutable());
 					} else {
-						destTable.createColumn(colName, sourceColumn.getType(), 
+						destTable.createColumn(stringObjectEntry.getKey(), sourceColumn.getType(), 
 						                       sourceColumn.isImmutable());
 					}
 				} else if (column.isPrimaryKey()) {
@@ -450,7 +450,7 @@ public class ClipboardImpl {
 				// the targetTable are the same, and this column is virtual, we don't
 				// want to copy it.
 				try {
-					targetRow.set(colName, oldDataMap.get(colName));
+					targetRow.set(stringObjectEntry.getKey(), stringObjectEntry.getValue());
 				} catch (IllegalArgumentException e) {
 					// Log a warning
 					System.out.println("Set failed!  "+e);

--- a/equations-impl/src/test/java/org/cytoscape/equations/internal/builtins/Framework.java
+++ b/equations-impl/src/test/java/org/cytoscape/equations/internal/builtins/Framework.java
@@ -64,8 +64,8 @@ class Framework {
 	 */
 	static boolean executeTest(final String equation, final Map<String, Object> variablesAndValues, final Object expectedResult) {
 		final Map<String, Class<?>> varNameToTypeMap = new HashMap<String, Class<?>>();
-		for (final String variableName : variablesAndValues.keySet())
-			varNameToTypeMap.put(variableName, variablesAndValues.get(variableName).getClass());
+		for (final Map.Entry<String, Object> entry : variablesAndValues.entrySet())
+			varNameToTypeMap.put(entry.getKey(), entry.getValue().getClass());
 		
 		try {
 			if (!compiler.compile(equation, varNameToTypeMap)) {
@@ -79,8 +79,8 @@ class Framework {
 
 		final Map<String, IdentDescriptor> nameToDescriptorMap = new HashMap<String, IdentDescriptor>();
 		try {
-			for (final String variableName : variablesAndValues.keySet())
-				nameToDescriptorMap.put(variableName, new IdentDescriptor(variablesAndValues.get(variableName)));
+			for (final Map.Entry<String, Object> entry : variablesAndValues.entrySet())
+				nameToDescriptorMap.put(entry.getKey(), new IdentDescriptor(entry.getValue()));
 		} catch (final Exception e) {
 			System.err.println("Error while processing variables for \"" + equation + "\": " + e.getMessage());
 			return false;
@@ -115,8 +115,8 @@ class Framework {
 	 */
 	static boolean executeTestExpectFailure(final String equation, final Map<String, Object> variablesAndValues) {
 		final Map<String, Class<?>> varNameToTypeMap = new HashMap<String, Class<?>>();
-		for (final String variableName : variablesAndValues.keySet())
-			varNameToTypeMap.put(variableName, variablesAndValues.get(variableName).getClass());
+		for (final Map.Entry<String, Object> entry : variablesAndValues.entrySet())
+			varNameToTypeMap.put(entry.getKey(), entry.getValue().getClass());
 		
 		try {
 			if (!compiler.compile(equation, varNameToTypeMap)) {
@@ -130,8 +130,8 @@ class Framework {
 
 		final Map<String, IdentDescriptor> nameToDescriptorMap = new HashMap<String, IdentDescriptor>();
 		try {
-			for (final String variableName : variablesAndValues.keySet())
-				nameToDescriptorMap.put(variableName, new IdentDescriptor(variablesAndValues.get(variableName)));
+			for (final Map.Entry<String, Object> entry : variablesAndValues.entrySet())
+				nameToDescriptorMap.put(entry.getKey(), new IdentDescriptor(entry.getValue()));
 		} catch (final Exception e) {
 			System.err.println("Error while processing variables for \"" + equation + "\": " + e.getMessage());
 			return true;

--- a/group-impl/src/main/java/org/cytoscape/group/internal/CyGroupImpl.java
+++ b/group-impl/src/main/java/org/cytoscape/group/internal/CyGroupImpl.java
@@ -1006,9 +1006,9 @@ public class CyGroupImpl implements CyGroup {
 	protected void removeMetaEdge(CyEdge edge) {
 		synchronized (lock) {
 			if (!metaEdges.containsValue(edge))
-				for (CyEdge metaKey: metaEdges.keySet()) {
-					if (metaEdges.get(metaKey).equals(edge))
-						metaEdges.remove(metaKey);
+				for (Map.Entry<CyEdge, CyEdge> entry : metaEdges.entrySet()) {
+					if (entry.getValue().equals(edge))
+						metaEdges.remove(entry.getKey());
 				}
 		}
 	}

--- a/group-impl/src/main/java/org/cytoscape/group/internal/data/CyGroupSettingsImpl.java
+++ b/group-impl/src/main/java/org/cytoscape/group/internal/data/CyGroupSettingsImpl.java
@@ -347,13 +347,13 @@ public class CyGroupSettingsImpl implements GroupAddedListener,
 			}
 		}
 		synchronized (lock) {
-			for (Class<?> cKey: allGroupDefaultMap.keySet())
-				defMap.put(cKey, allGroupDefaultMap.get(cKey));
-			for (Class<?> cKey: allGroupListDefaultMap.keySet())
-				defListMap.put(cKey, allGroupListDefaultMap.get(cKey));
+			for (Map.Entry<Class<?>, Aggregator<?>> entry : allGroupDefaultMap.entrySet())
+				defMap.put(entry.getKey(), entry.getValue());
+			for (Map.Entry<Class<?>, Aggregator<?>> entry : allGroupListDefaultMap.entrySet())
+				defListMap.put(entry.getKey(), entry.getValue());
 			Map<CyColumn,Aggregator<?>> ovMap = new HashMap<CyColumn, Aggregator<?>>();
-			for (CyColumn cKey: allGroupOverrideMap.keySet())
-				ovMap.put(cKey, allGroupOverrideMap.get(cKey));
+			for (Map.Entry<CyColumn, Aggregator<?>> entry : allGroupOverrideMap.entrySet())
+				ovMap.put(entry.getKey(), entry.getValue());
 			groupMap.put(addedGroup, new GroupSpecificMaps(defMap, defListMap, ovMap));
 		}
 		// Now override these with any settings from the table
@@ -761,8 +761,8 @@ public class CyGroupSettingsImpl implements GroupAddedListener,
 			if (overrides == null || overrides.size() == 0)
 				return;
 
-			for (CyColumn column: overrides.keySet()) {
-				aggrOverrideSettings.add(column.getName()+"="+overrides.get(column).toString());
+			for (Map.Entry<CyColumn, Aggregator<?>> entry : overrides.entrySet()) {
+				aggrOverrideSettings.add(entry.getKey().getName()+"="+ entry.getValue().toString());
 			}
 
 			// currentNetwork.getRow(group.getGroupNode(), CyNetwork.HIDDEN_ATTRS).set(AGGREGATION_OVERRIDE_SETTINGS, aggrOverrideSettings);
@@ -901,11 +901,11 @@ public class CyGroupSettingsImpl implements GroupAddedListener,
 	 */
 	public String encodeAggregationOverrides() {
 		String str = "";
-		for (CyColumn column: allGroupOverrideMap.keySet()) {
+		for (Map.Entry<CyColumn, Aggregator<?>> entry : allGroupOverrideMap.entrySet()) {
 			if (str.length() == 0)
-				str = column.getName()+"="+allGroupOverrideMap.get(column).toString();
+				str = entry.getKey().getName()+"="+ entry.getValue().toString();
 			else
-				str += "\t"+column.getName()+"="+allGroupOverrideMap.get(column).toString();
+				str += "\t"+ entry.getKey().getName()+"="+ entry.getValue().toString();
 		}
 		return str;
 	}

--- a/group-impl/src/main/java/org/cytoscape/group/internal/data/CyGroupSettingsTask.java
+++ b/group-impl/src/main/java/org/cytoscape/group/internal/data/CyGroupSettingsTask.java
@@ -99,11 +99,11 @@ public class CyGroupSettingsTask extends AbstractTask {
 
 		// Get any overrides
 		Map<CyColumn, Aggregator<?>> overrides = aggregationSettings.getOverrideMap();
-		for (CyColumn column: overrides.keySet()) {
+		for (Map.Entry<CyColumn, Aggregator<?>> entry : overrides.entrySet()) {
 			if (group != null)
-				settings.setOverrideAggregation(group, column, overrides.get(column));
+				settings.setOverrideAggregation(group, entry.getKey(), entry.getValue());
 			else
-				settings.setOverrideAggregation(column, overrides.get(column));
+				settings.setOverrideAggregation(entry.getKey(), entry.getValue());
 		}
 	}
 	

--- a/io-impl/impl/src/main/java/org/cytoscape/io/internal/read/gml/GMLNetworkReader.java
+++ b/io-impl/impl/src/main/java/org/cytoscape/io/internal/read/gml/GMLNetworkReader.java
@@ -578,8 +578,8 @@ public class GMLNetworkReader extends AbstractCyNetworkReader {
 
 	private void setAttributes(final CyIdentifiable obj,
 			final CyNetwork network, final Map<String, Object> attrMap) {
-		for (String name : attrMap.keySet()) {
-			final Object val = attrMap.get(name);
+		for (Map.Entry<String, Object> entry : attrMap.entrySet()) {
+			final Object val = entry.getValue();
 
 			if (val == null)
 				continue;
@@ -595,21 +595,21 @@ public class GMLNetworkReader extends AbstractCyNetworkReader {
 
 			final CyRow row = network.getRow(obj);
 			final CyTable table = row.getTable();
-			final CyColumn column = table.getColumn(name);
+			final CyColumn column = table.getColumn(entry.getKey());
 
 			if (column == null)
-				table.createColumn(name, type, false);
+				table.createColumn(entry.getKey(), type, false);
 
 			try {
 				if (type == Double.class)
-					row.set(name, (Double) val);
+					row.set(entry.getKey(), (Double) val);
 				else if (type == Integer.class)
-					row.set(name, (Integer) val);
+					row.set(entry.getKey(), (Integer) val);
 				else
-					row.set(name, val.toString());
+					row.set(entry.getKey(), val.toString());
 			} catch (Exception e) {
 				logger.error("Cannot set value \"" + val + "\" (" + type
-						+ ") to column \"" + name + "\" of table \"" + table
+						+ ") to column \"" + entry.getKey() + "\" of table \"" + table
 						+ "\".", e);
 				continue;
 			}

--- a/io-impl/impl/src/main/java/org/cytoscape/io/internal/read/xgmml/GenericXGMMLReader.java
+++ b/io-impl/impl/src/main/java/org/cytoscape/io/internal/read/xgmml/GenericXGMMLReader.java
@@ -305,26 +305,26 @@ public class GenericXGMMLReader extends AbstractCyNetworkReader {
 
 			final Set<String> attSet = atts.keySet();
 
-			for (final String attName : attSet) {
-				String attValue = atts.get(attName);
-				final VisualProperty vp = visualLexicon.lookup(type, attName);
+			for (final Map.Entry<String, String> entry : atts.entrySet()) {
+				String attValue = entry.getValue();
+				final VisualProperty vp = visualLexicon.lookup(type, entry.getKey());
 				
 				if (vp != null) {
-					if (isXGMMLTransparency(attName))
+					if (isXGMMLTransparency(entry.getKey()))
 						attValue = convertXGMMLTransparencyValue(attValue);
-					else if (isOldArrowShape(attName))
+					else if (isOldArrowShape(entry.getKey()))
 						attValue = convertOldArrowShapeValue(attValue);
 					
 					final Object parsedValue = vp.parseSerializableString(attValue);
 
 					if (parsedValue != null) {
-						if (isLockedVisualProperty(model, attName))
+						if (isLockedVisualProperty(model, entry.getKey()))
 							view.setLockedValue(vp, parsedValue);
 						else
 							view.setVisualProperty(vp, parsedValue);
 					}
 				} else {
-					unrecognizedVisualPropertyMgr.addUnrecognizedVisualProperty(netView, view, attName, attValue);
+					unrecognizedVisualPropertyMgr.addUnrecognizedVisualProperty(netView, view, entry.getKey(), attValue);
 				}
 			}
 		}

--- a/jobs-impl/src/main/java/org/cytoscape/jobs/internal/CyJobManagerImpl.java
+++ b/jobs-impl/src/main/java/org/cytoscape/jobs/internal/CyJobManagerImpl.java
@@ -251,22 +251,22 @@ public class CyJobManagerImpl implements CyJobManager,
 		public void run() {
 			resetTimer();
 			List<CyJob> orphans = new ArrayList<>();
-			for (CyJob job: intervalMap.keySet()) {
-				if (intervalMap.get(job).ready()) {
-					CyJobStatus status = job.getJobExecutionService().checkJobStatus(job);
-					if (statusMap.containsKey(job) && statusMap.get(job).equals(status))
+			for (Map.Entry<CyJob, IntervalCounter> entry : intervalMap.entrySet()) {
+				if (entry.getValue().ready()) {
+					CyJobStatus status = entry.getKey().getJobExecutionService().checkJobStatus(entry.getKey());
+					if (statusMap.containsKey(entry.getKey()) && statusMap.get(entry.getKey()).equals(status))
 						continue;
 
-					if (jobMonitorMap.containsKey(job))
-						jobMonitorMap.get(job).jobStatusChanged(job, status);
+					if (jobMonitorMap.containsKey(entry.getKey()))
+						jobMonitorMap.get(entry.getKey()).jobStatusChanged(entry.getKey(), status);
 
 					if (status.isDone())
 						// Orphan
-						orphans.add(job);
+						orphans.add(entry.getKey());
 
-					statusMap.put(job, status);
+					statusMap.put(entry.getKey(), status);
 					// The jobMonitor should call loadResults
-					jobMonitor.jobStatusChanged(job, status);
+					jobMonitor.jobStatusChanged(entry.getKey(), status);
 				}
 			}
 			for (CyJob job: orphans) removeJob(job);

--- a/linkout-impl/src/main/java/org/cytoscape/linkout/internal/DynamicSupport.java
+++ b/linkout-impl/src/main/java/org/cytoscape/linkout/internal/DynamicSupport.java
@@ -129,15 +129,15 @@ import org.cytoscape.work.TaskIterator;
 
 		setURLs(network, entries);
 		
-		for(final String menuTitle: menuTitleURLMap.keySet()){
-			JMenuItem subMenu = new JMenuItem(menuTitle);
+		for(final Map.Entry<String, String> entry : menuTitleURLMap.entrySet()){
+			JMenuItem subMenu = new JMenuItem(entry.getKey());
 			subMenu.addActionListener(new ActionListener() {
 
 				@Override
 				public void actionPerformed(ActionEvent e) {
 					String url = "none found"; 
 					synchronized (this) {
-						url = menuTitleURLMap.get( menuTitle );	
+						url = entry.getValue();	
 					}
 					synTaskManager.execute(new TaskIterator(new LinkoutTask(url, browser, network, tableEntries )));
 				}

--- a/model-impl/impl/src/main/java/org/cytoscape/model/internal/CyNetworkTableManagerImpl.java
+++ b/model-impl/impl/src/main/java/org/cytoscape/model/internal/CyNetworkTableManagerImpl.java
@@ -73,9 +73,9 @@ public class CyNetworkTableManagerImpl implements CyNetworkTableManager {
 		synchronized (lock) {
 			for (Map<Class<? extends CyIdentifiable>, Map<String, CyTable>> typeMap: tables.values()) {
 				for (Map<String, CyTable> stMap: typeMap.values()) {
-					for (String ns: stMap.keySet()) {
-						if (stMap.get(ns).equals(table)) {
-							return ns;
+					for (Entry<String, CyTable> entry : stMap.entrySet()) {
+						if (entry.getValue().equals(table)) {
+							return entry.getKey();
 						}
 					}
 				}

--- a/model-impl/impl/src/main/java/org/cytoscape/model/internal/CyTableImpl.java
+++ b/model-impl/impl/src/main/java/org/cytoscape/model/internal/CyTableImpl.java
@@ -228,11 +228,11 @@ public final class CyTableImpl implements CyTable, TableAddedListener {
 		if (oldColumnName.equalsIgnoreCase(newColumnName))
 			return;
 
-		for(final String curColumnName : types.keySet())
-			if (curColumnName.equalsIgnoreCase(newColumnName))
+		for(final Entry<String, CyColumn> entry : types.entrySet())
+			if (entry.getKey().equalsIgnoreCase(newColumnName))
 				throw new IllegalArgumentException("column already exists with name: '"
-					   + curColumnName + "' with type: "
-					   + types.get(curColumnName).getType());
+					   + entry.getKey() + "' with type: "
+					   + entry.getValue().getType());
 		
 		synchronized(lock) {
 			if (currentlyActiveAttributes.remove(oldColumnName)) {
@@ -701,9 +701,9 @@ public final class CyTableImpl implements CyTable, TableAddedListener {
 				String normalizedTargetJoinKey = table2.normalizeColumnName(targetJoinKey);		
 				Map<Object, Object> keyToValueMap = table2.attributes.get(normalizedTargetJoinKey);
 				if(keyToValueMap != null) {
-					for (Object key2: keyToValueMap.keySet()) {
-						if (keyToValueMap.get(key2).equals(key)) {
-							fireVirtualColumnRowSetEvent(table2, key2, dependent.getName(), newValue, newRawValue, seen);
+					for (Entry<Object, Object> entry : keyToValueMap.entrySet()) {
+						if (entry.getValue().equals(key)) {
+							fireVirtualColumnRowSetEvent(table2, entry.getKey(), dependent.getName(), newValue, newRawValue, seen);
 						}
 					}
 				}

--- a/model-impl/impl/src/main/java/org/cytoscape/model/internal/CyTableManagerImpl.java
+++ b/model-impl/impl/src/main/java/org/cytoscape/model/internal/CyTableManagerImpl.java
@@ -126,9 +126,9 @@ public class CyTableManagerImpl implements CyTableManager, NetworkAboutToBeDestr
 		synchronized (lock) {
 			final Set<CyTable> res = new HashSet<CyTable>();
 	
-			for (final Long key : tables.keySet()) {
-				if (includePrivate || tables.get(key).isPublic())
-					res.add(tables.get(key));
+			for (final Map.Entry<Long, CyTable> entry : tables.entrySet()) {
+				if (includePrivate || entry.getValue().isPublic())
+					res.add(entry.getValue());
 			}
 	
 			return res;

--- a/swing-application-impl/src/main/java/org/cytoscape/internal/layout/ui/LayoutMenuPopulator.java
+++ b/swing-application-impl/src/main/java/org/cytoscape/internal/layout/ui/LayoutMenuPopulator.java
@@ -97,8 +97,8 @@ public class LayoutMenuPopulator implements MenuListener {
         boolean enableMenuItem = checkEnabled();
 
         // Get all of the algorithms
-        for ( CyLayoutAlgorithm layout : algorithmMap.keySet() ) {
-            Map props = algorithmMap.get(layout);
+        for (Map.Entry<CyLayoutAlgorithm, Map> entry : algorithmMap.entrySet()) {
+            Map props = entry.getValue();
             double gravity = 1000.0;
             if (props.get(MENU_GRAVITY) != null)
                 gravity = Double.parseDouble((String)props.get(MENU_GRAVITY));
@@ -112,35 +112,35 @@ public class LayoutMenuPopulator implements MenuListener {
                 separatorBefore = Boolean.parseBoolean((String)props.get(INSERT_SEPARATOR_BEFORE));
 
             // Remove the old menu
-            if (menuMap.containsKey(layout)) {
-                layoutMenu.remove(menuMap.remove(layout));
+            if (menuMap.containsKey(entry.getKey())) {
+                layoutMenu.remove(menuMap.remove(entry.getKey()));
             }
         
             boolean usesNodeAttrs = false;
             if (network != null)
-                usesNodeAttrs = hasValidAttributes(layout.getSupportedNodeAttributeTypes(),network.getDefaultNodeTable());
+                usesNodeAttrs = hasValidAttributes(entry.getKey().getSupportedNodeAttributeTypes(),network.getDefaultNodeTable());
             boolean usesEdgeAttrs = false;
             if (network != null)
-                usesEdgeAttrs = hasValidAttributes(layout.getSupportedEdgeAttributeTypes(),network.getDefaultEdgeTable());
-            boolean usesSelected = (layout.getSupportsSelectedOnly() && someSelected);
+                usesEdgeAttrs = hasValidAttributes(entry.getKey().getSupportedEdgeAttributeTypes(),network.getDefaultEdgeTable());
+            boolean usesSelected = (entry.getKey().getSupportsSelectedOnly() && someSelected);
 
             if (usesNodeAttrs || usesEdgeAttrs || usesSelected) {
-                JMenu newMenu = new DynamicLayoutMenu(layout,network,enableMenuItem,appMgr,
+                JMenu newMenu = new DynamicLayoutMenu(entry.getKey(),network,enableMenuItem,appMgr,
                                                       tm,usesNodeAttrs,usesEdgeAttrs,usesSelected);
-                menuMap.put(layout, newMenu);
+                menuMap.put(entry.getKey(), newMenu);
                 gravityTracker.addMenu(newMenu, gravity);
             } else {
-                JMenuItem newMenu = new StaticLayoutMenu(layout,enableMenuItem,appMgr,tm);
-                menuMap.put(layout, newMenu);
+                JMenuItem newMenu = new StaticLayoutMenu(entry.getKey(),enableMenuItem,appMgr,tm);
+                menuMap.put(entry.getKey(), newMenu);
                 gravityTracker.addMenuItem(newMenu, gravity);
             }
 
-			if (separatorAfter && !separatorMap.containsKey(layout)) {
+			if (separatorAfter && !separatorMap.containsKey(entry.getKey())) {
 				gravityTracker.addMenuSeparator(gravity + 0.0001);
-				separatorMap.put(layout, Boolean.TRUE);
-			} else if (separatorBefore && !separatorMap.containsKey(layout)) {
+				separatorMap.put(entry.getKey(), Boolean.TRUE);
+			} else if (separatorBefore && !separatorMap.containsKey(entry.getKey())) {
 				gravityTracker.addMenuSeparator(gravity - 0.0001);
-				separatorMap.put(layout, Boolean.TRUE);
+				separatorMap.put(entry.getKey(), Boolean.TRUE);
 			}
         }
     }

--- a/table-browser-impl/src/main/java/org/cytoscape/browser/internal/view/AbstractTableBrowser.java
+++ b/table-browser-impl/src/main/java/org/cytoscape/browser/internal/view/AbstractTableBrowser.java
@@ -283,10 +283,10 @@ public abstract class AbstractTableBrowser extends JPanel
 		Map<CyTable, BrowserTable>  browserTables = getAllBrowserTablesMap();
 		List<TableColumnStat> tableColumnStatList = new ArrayList<>();
 
-		for (CyTable table :  browserTables.keySet()){
-			TableColumnStat tcs = new TableColumnStat(table.getTitle());
+		for (Map.Entry<CyTable, BrowserTable> entry : browserTables.entrySet()){
+			TableColumnStat tcs = new TableColumnStat(entry.getKey().getTitle());
 
-			BrowserTable browserTable = browserTables.get(table);
+			BrowserTable browserTable = entry.getValue();
 			BrowserTableModel model = (BrowserTableModel) browserTable.getModel();
 			BrowserTableColumnModel colM = (BrowserTableColumnModel) browserTable.getColumnModel();
 			List<String> visAttrs = browserTable.getVisibleAttributeNames();

--- a/table-import-impl/src/main/java/org/cytoscape/tableimport/internal/reader/DefaultAttributeTableReader.java
+++ b/table-import-impl/src/main/java/org/cytoscape/tableimport/internal/reader/DefaultAttributeTableReader.java
@@ -187,8 +187,8 @@ public class DefaultAttributeTableReader implements TextTableReader {
 			sb.append("\n\nThe following enties are invalid and were not imported:\n");
 			int limit = 10;
 			
-			for (String key : invalid.keySet()) {
-				sb.append(key + " = " + invalid.get(key) + "\n");
+			for (Map.Entry<String, Object> entry : invalid.entrySet()) {
+				sb.append(entry.getKey() + " = " + entry.getValue() + "\n");
 				
 				if (limit-- <= 0) {
 					sb.append("Approximately " + (invalid.size() - 10) + " additional entries were not imported...");

--- a/table-import-impl/src/main/java/org/cytoscape/tableimport/internal/reader/ExcelAttributeSheetReader.java
+++ b/table-import-impl/src/main/java/org/cytoscape/tableimport/internal/reader/ExcelAttributeSheetReader.java
@@ -131,8 +131,8 @@ public class ExcelAttributeSheetReader implements TextTableReader {
 		if (invalid.size() > 0) {
 			sb.append("\n\nThe following enties are invalid and were not imported:\n");
 
-			for (String key : invalid.keySet()) {
-				sb.append(key + " = " + invalid.get(key) + "\n");
+			for (Map.Entry<String, Object> entry : invalid.entrySet()) {
+				sb.append(entry.getKey() + " = " + entry.getValue() + "\n");
 				if ( limit-- <= 0 ) {
 					sb.append("Approximately " + (invalid.size() - 10) +
 					          " additional entries were not imported...");

--- a/table-import-impl/src/main/java/org/cytoscape/tableimport/internal/reader/ontology/GeneAssociationReader.java
+++ b/table-import-impl/src/main/java/org/cytoscape/tableimport/internal/reader/ontology/GeneAssociationReader.java
@@ -209,10 +209,10 @@ public class GeneAssociationReader extends AbstractTask implements CyTableReader
 		}
 
 		// Create one column per namespace
-		for (String name : NAMESPACE_MAP.keySet()) {
-			table.createListColumn(NAMESPACE_MAP.get(name), String.class, false);
-			table.createListColumn(NAMESPACE_MAP.get(name) + EVIDENCE_SUFFIX, String.class, false);
-			table.createListColumn(NAMESPACE_MAP.get(name) + REFERENCE_SUFFIX, String.class, false);
+		for (Map.Entry<String, String> entry : NAMESPACE_MAP.entrySet()) {
+			table.createListColumn(entry.getValue(), String.class, false);
+			table.createListColumn(entry.getValue() + EVIDENCE_SUFFIX, String.class, false);
+			table.createListColumn(entry.getValue() + REFERENCE_SUFFIX, String.class, false);
 		}
 
 		// Consolidated entry name list

--- a/vizmap-gui-impl/src/main/java/org/cytoscape/view/vizmap/gui/internal/model/AttributeSetProxy.java
+++ b/vizmap-gui-impl/src/main/java/org/cytoscape/view/vizmap/gui/internal/model/AttributeSetProxy.java
@@ -167,14 +167,14 @@ public class AttributeSetProxy extends Proxy
 		final String newAttrName = e.getColumnName();
 		final CyTable table = e.getSource();
 
-		for (CyNetwork network : tableSets.keySet()) {
-			Map<Class<? extends CyIdentifiable>, Set<CyTable>> tMap = tableSets.get(network);
+		for (Map.Entry<CyNetwork, Map<Class<? extends CyIdentifiable>, Set<CyTable>>> cyNetworkMapEntry : tableSets.entrySet()) {
+			Map<Class<? extends CyIdentifiable>, Set<CyTable>> tMap = cyNetworkMapEntry.getValue();
 			
 			for (final Class<? extends CyIdentifiable> objectType : graphObjects) {
 				final Set<CyTable> targetTables = tMap.get(objectType);
 				
 				if (targetTables.contains(table)) {
-					attrSets.get(network)
+					attrSets.get(cyNetworkMapEntry.getKey())
 							.get(objectType)
 							.getAttrMap()
 							.put(newAttrName, table.getColumn(newAttrName).getType());
@@ -188,14 +188,14 @@ public class AttributeSetProxy extends Proxy
 	public void handleEvent(final ColumnDeletedEvent e) {
 		final CyTable table = e.getSource();
 
-		for (CyNetwork network : tableSets.keySet()) {
-			Map<Class<? extends CyIdentifiable>, Set<CyTable>> tMap = tableSets.get(network);
+		for (Map.Entry<CyNetwork, Map<Class<? extends CyIdentifiable>, Set<CyTable>>> cyNetworkMapEntry : tableSets.entrySet()) {
+			Map<Class<? extends CyIdentifiable>, Set<CyTable>> tMap = cyNetworkMapEntry.getValue();
 			
 			for (final Class<? extends CyIdentifiable> objectType : graphObjects) {
 				final Set<CyTable> targetTables = tMap.get(objectType);
 				
 				if (targetTables.contains(table)) {
-					attrSets.get(network).get(objectType).getAttrMap().remove(e.getColumnName());
+					attrSets.get(cyNetworkMapEntry.getKey()).get(objectType).getAttrMap().remove(e.getColumnName());
 					
 					return;
 				}
@@ -207,18 +207,18 @@ public class AttributeSetProxy extends Proxy
 	public void handleEvent(final ColumnNameChangedEvent e) {
 		final CyTable table = e.getSource();
 
-		for (CyNetwork network : tableSets.keySet()) {
-			Map<Class<? extends CyIdentifiable>, Set<CyTable>> tMap = tableSets.get(network);
+		for (Map.Entry<CyNetwork, Map<Class<? extends CyIdentifiable>, Set<CyTable>>> cyNetworkMapEntry : tableSets.entrySet()) {
+			Map<Class<? extends CyIdentifiable>, Set<CyTable>> tMap = cyNetworkMapEntry.getValue();
 			
 			for (final Class<? extends CyIdentifiable> objectType : graphObjects) {
 				final Set<CyTable> targetTables = tMap.get(objectType);
 				
 				if (targetTables.contains(table)) {
-					attrSets.get(network)
+					attrSets.get(cyNetworkMapEntry.getKey())
 							.get(objectType)
 							.getAttrMap()
 							.remove(e.getOldColumnName());
-					attrSets.get(network)
+					attrSets.get(cyNetworkMapEntry.getKey())
 							.get(objectType)
 							.getAttrMap()
 							.put(e.getNewColumnName(), table.getColumn(e.getNewColumnName()).getType());

--- a/vizmap-gui-impl/src/main/java/org/cytoscape/view/vizmap/gui/internal/view/editor/EditorManagerImpl.java
+++ b/vizmap-gui-impl/src/main/java/org/cytoscape/view/vizmap/gui/internal/view/editor/EditorManagerImpl.java
@@ -250,8 +250,8 @@ public class EditorManagerImpl implements EditorManager {
 	public List<PropertyEditor> getCellEditors() {
 		List<PropertyEditor> ret = new ArrayList<PropertyEditor>();
 
-		for (Class<?> type : editors.keySet())
-			ret.add(editors.get(type).getPropertyEditor());
+		for (Map.Entry<Class<?>, VisualPropertyEditor<?>> entry : editors.entrySet())
+			ret.add(entry.getValue().getPropertyEditor());
 
 		return ret;
 	}

--- a/vizmap-gui-impl/src/main/java/org/cytoscape/view/vizmap/gui/internal/view/editor/mappingeditor/C2CMappingEditorPanel.java
+++ b/vizmap-gui-impl/src/main/java/org/cytoscape/view/vizmap/gui/internal/view/editor/mappingeditor/C2CMappingEditorPanel.java
@@ -28,6 +28,7 @@ import java.awt.event.ActionEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.List;
+import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
@@ -191,8 +192,8 @@ public class C2CMappingEditorPanel<K extends Number, V extends Number> extends C
 			sortedPoints.put(val.doubleValue(), point);
 		}
 
-		for (Double key : sortedPoints.keySet()) {
-			ContinuousMappingPoint<K, V> point = sortedPoints.get(key);
+		for (Map.Entry<Double, ContinuousMappingPoint<K, V>> entry : sortedPoints.entrySet()) {
+			ContinuousMappingPoint<K, V> point = entry.getValue();
 			bound = point.getRange();
 			fraction = ((Number) ((point.getValue().doubleValue() - minValue.doubleValue()) / actualRange.doubleValue()))
 					.floatValue() * 100d;

--- a/vizmap-gui-impl/src/main/java/org/cytoscape/view/vizmap/gui/internal/view/editor/mappingeditor/ContinuousTrackRenderer.java
+++ b/vizmap-gui-impl/src/main/java/org/cytoscape/view/vizmap/gui/internal/view/editor/mappingeditor/ContinuousTrackRenderer.java
@@ -380,13 +380,13 @@ public class ContinuousTrackRenderer<K extends Number, V extends Number>
 		g.setColor(TRACK_COLOR);
 		g.setStroke(new BasicStroke(1.5f));
 
-		for (Integer key : verticesList.keySet()) {
-			Point p = verticesList.get(key);
+		for (Map.Entry<Integer, Point> entry : verticesList.entrySet()) {
+			Point p = entry.getValue();
 			if (clickFlag) {
 				int diffX = Math.abs(p.x - (curPoint.x - 6));
 				int diffY = Math.abs(p.y - (curPoint.y - 12));
 
-				if (((diffX < 6) && (diffY < 6)) || (key == selectedIdx)) {
+				if (((diffX < 6) && (diffY < 6)) || (entry.getKey() == selectedIdx)) {
 					g.setColor(FOCUS_COLOR);
 					g.setStroke(new BasicStroke(2.5f));
 				} else {

--- a/vizmap-gui-impl/src/main/java/org/cytoscape/view/vizmap/gui/internal/view/editor/mappingeditor/GradientEditorPanel.java
+++ b/vizmap-gui-impl/src/main/java/org/cytoscape/view/vizmap/gui/internal/view/editor/mappingeditor/GradientEditorPanel.java
@@ -31,6 +31,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.List;
+import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
@@ -229,8 +230,8 @@ public class GradientEditorPanel<T extends Number> extends ContinuousMappingEdit
 			sortedPoints.put(val.doubleValue(), point);
 		}
 
-		for (Double key : sortedPoints.keySet()) {
-			final ContinuousMappingPoint<T, Color> point = sortedPoints.get(key);
+		for (Map.Entry<Double, ContinuousMappingPoint<T, Color>> entry : sortedPoints.entrySet()) {
+			final ContinuousMappingPoint<T, Color> point = entry.getValue();
 			BoundaryRangeValues<Color> bound = point.getRange();
 
 			getSlider().getModel().addThumb(


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2864 - “"entrySet()" should be iterated when both the key and value are needed ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2864
Please let me know if you have any questions.
Ayman Abdelghany.
