### PR TITLE
Collections.emptyList(), emptyMap() and emptySet() should be used instead of Collections.EMPTY_LIST, EMPTY_MAP and EMPTY_SET

### DIFF
--- a/application-impl/src/test/java/org/cytoscape/application/internal/CyApplicationManagerImplTest.java
+++ b/application-impl/src/test/java/org/cytoscape/application/internal/CyApplicationManagerImplTest.java
@@ -302,9 +302,9 @@ public class CyApplicationManagerImplTest {
 		NetworkViewRenderer renderer3 = mock(NetworkViewRenderer.class);
 		when(renderer3.getId()).thenReturn("A");
 		
-		appMgr.addNetworkViewRenderer(renderer1, Collections.EMPTY_MAP);
-		appMgr.addNetworkViewRenderer(renderer2, Collections.EMPTY_MAP);
-		appMgr.addNetworkViewRenderer(renderer3, Collections.EMPTY_MAP);
+		appMgr.addNetworkViewRenderer(renderer1, Collections.emptyMap());
+		appMgr.addNetworkViewRenderer(renderer2, Collections.emptyMap());
+		appMgr.addNetworkViewRenderer(renderer3, Collections.emptyMap());
 		
 		assertEquals(3, appMgr.getNetworkViewRendererSet().size());
 		assertEquals(renderer1, appMgr.getDefaultNetworkViewRenderer());

--- a/core-task-impl/src/main/java/org/cytoscape/task/internal/creation/NewEmptyNetworkTask.java
+++ b/core-task-impl/src/main/java/org/cytoscape/task/internal/creation/NewEmptyNetworkTask.java
@@ -158,7 +158,7 @@ public class NewEmptyNetworkTask extends AbstractTask {
 			if (defViewRenderer != null && viewRenderers.contains(defViewRenderer))
 				renderers.setSelectedValue(defViewRenderer);
 		} else {
-			renderers = new ListSingleSelection<>(Collections.EMPTY_LIST);
+			renderers = new ListSingleSelection<>(Collections.emptyList());
 		}
 	}
 

--- a/core-task-impl/src/test/java/org/cytoscape/task/internal/creation/CreateNetworkViewTaskTest.java
+++ b/core-task-impl/src/test/java/org/cytoscape/task/internal/creation/CreateNetworkViewTaskTest.java
@@ -73,7 +73,7 @@ public class CreateNetworkViewTaskTest {
 	public void setUp() throws Exception {
 		MockitoAnnotations.initMocks(this);
 		when(vmm.getCurrentVisualStyle()).thenReturn(currentStyle);
-		when(renderingEngineManager.getRenderingEngines(any(View.class))).thenReturn(Collections.EMPTY_LIST);
+		when(renderingEngineManager.getRenderingEngines(any(View.class))).thenReturn(Collections.<org.cytoscape.view.presentation.RenderingEngine<?>>emptyList());
 	}
 	
 	@Test

--- a/core-task-impl/src/test/java/org/cytoscape/task/internal/creation/NewNetworkSelectedNodesEdgesTaskTest.java
+++ b/core-task-impl/src/test/java/org/cytoscape/task/internal/creation/NewNetworkSelectedNodesEdgesTaskTest.java
@@ -84,7 +84,7 @@ public class NewNetworkSelectedNodesEdgesTaskTest {
 		when(serviceRegistrar.getService(CyEventHelper.class)).thenReturn(eventHelper);
         when(serviceRegistrar.getService(CyNetworkNaming.class)).thenReturn(namingUtil);
 		
-		when(renderingEngineManager.getRenderingEngines(any(View.class))).thenReturn(Collections.EMPTY_LIST);
+		when(renderingEngineManager.getRenderingEngines(any(View.class))).thenReturn(Collections.<org.cytoscape.view.presentation.RenderingEngine<?>>emptyList());
 	}
 
 	@Test

--- a/core-task-impl/src/test/java/org/cytoscape/task/internal/creation/NewNetworkSelectedNodesOnlyTaskTest.java
+++ b/core-task-impl/src/test/java/org/cytoscape/task/internal/creation/NewNetworkSelectedNodesOnlyTaskTest.java
@@ -84,7 +84,7 @@ public class NewNetworkSelectedNodesOnlyTaskTest {
 		when(serviceRegistrar.getService(CyEventHelper.class)).thenReturn(eventHelper);
         when(serviceRegistrar.getService(CyNetworkNaming.class)).thenReturn(namingUtil);
 		
-		when(renderingEngineManager.getRenderingEngines(any(View.class))).thenReturn(Collections.EMPTY_LIST);
+		when(renderingEngineManager.getRenderingEngines(any(View.class))).thenReturn(Collections.<org.cytoscape.view.presentation.RenderingEngine<?>>emptyList());
 	}
 	
 	@Test

--- a/core-task-impl/src/test/java/org/cytoscape/task/internal/session/OpenSessionTaskTest.java
+++ b/core-task-impl/src/test/java/org/cytoscape/task/internal/session/OpenSessionTaskTest.java
@@ -72,7 +72,7 @@ public class OpenSessionTaskTest {
 	public void initMocks() {
 		MockitoAnnotations.initMocks(this);
 		
-		when(netTableMgr.getNetworkSet()).thenReturn(Collections.EMPTY_SET);
+		when(netTableMgr.getNetworkSet()).thenReturn(Collections.<org.cytoscape.model.CyNetwork>emptySet());
 		
 		sampleFile = new File("./src/test/resources/test_session1.cys");
 		when(readerMgr.getReader(sampleFile.toURI(),sampleFile.getName())).thenReturn(reader);

--- a/core-task-impl/src/test/java/org/cytoscape/task/internal/table/MappingIntegrationTest.java
+++ b/core-task-impl/src/test/java/org/cytoscape/task/internal/table/MappingIntegrationTest.java
@@ -115,7 +115,7 @@ public class MappingIntegrationTest {
         when(serviceRegistrar.getService(TunableSetter.class)).thenReturn(ts);
         when(serviceRegistrar.getService(CyApplicationManager.class)).thenReturn(appMgr);
         
-		when(renderingEngineManager.getRenderingEngines(any(View.class))).thenReturn(Collections.EMPTY_LIST);
+		when(renderingEngineManager.getRenderingEngines(any(View.class))).thenReturn(Collections.<org.cytoscape.view.presentation.RenderingEngine<?>>emptyList());
 	}
 	
 	@Test

--- a/core-task-impl/src/test/java/org/cytoscape/task/internal/table/MergeDataTableTaskTest.java
+++ b/core-task-impl/src/test/java/org/cytoscape/task/internal/table/MergeDataTableTaskTest.java
@@ -109,7 +109,7 @@ public class MergeDataTableTaskTest {
 		when(serviceRegistrar.getService(CyEventHelper.class)).thenReturn(eventHelper);
         when(serviceRegistrar.getService(CyNetworkNaming.class)).thenReturn(namingUtil);
 		
-		when(renderingEngineManager.getRenderingEngines(any(View.class))).thenReturn(Collections.EMPTY_LIST);
+		when(renderingEngineManager.getRenderingEngines(any(View.class))).thenReturn(Collections.<org.cytoscape.view.presentation.RenderingEngine<?>>emptyList());
 	}
 	
 	@Test

--- a/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/impl/DNodeDetails.java
+++ b/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/impl/DNodeDetails.java
@@ -735,7 +735,7 @@ public class DNodeDetails extends NodeDetails {
 	public Map<VisualProperty<CyCustomGraphics>, CustomGraphicsInfo> getCustomGraphics(final CyNode node) {
 		final DNodeView dnv = dGraphView.getDNodeView(node);
 		
-		return dnv != null ? dnv.getCustomGraphics() : Collections.EMPTY_MAP;
+		return dnv != null ? dnv.getCustomGraphics() : Collections.emptyMap();
 	}
 	
 	@Override

--- a/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/impl/cyannotator/CyAnnotator.java
+++ b/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/impl/cyannotator/CyAnnotator.java
@@ -151,7 +151,7 @@ public class CyAnnotator {
 
 		if (networkAttributes.getColumn(ANNOTATION_ATTRIBUTE) == null) {
 			networkAttributes.createListColumn(ANNOTATION_ATTRIBUTE,
-			                                   String.class,false,Collections.EMPTY_LIST);
+			                                   String.class,false, Collections.<String>emptyList());
 		}
 
 		List<String> annotations = network.getRow(network, CyNetwork.LOCAL_ATTRS).

--- a/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/internal/charts/box/BoxLayer.java
+++ b/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/internal/charts/box/BoxLayer.java
@@ -45,7 +45,7 @@ public class BoxLayer extends AbstractChartLayer<BoxAndWhiskerCategoryDataset> {
 					final List<Double> range,
 					final Orientation orientation,
 					final Rectangle2D bounds) {
-        super(data, Collections.EMPTY_LIST, Collections.EMPTY_LIST, Collections.EMPTY_LIST, false, false,
+        super(data, Collections.<String>emptyList(), Collections.<String>emptyList(), Collections.<String>emptyList(), false, false,
 				showRangeAxis, 0.0f, LabelPosition.STANDARD, colors, axisWidth, axisColor, axisFontSize,
 				borderWidth, borderColor, range, bounds);
         this.showRangeZeroBaseline = showRangeZeroBaseline;

--- a/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/internal/charts/ring/RingLayer.java
+++ b/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/internal/charts/ring/RingLayer.java
@@ -129,7 +129,7 @@ public class RingLayer extends AbstractChartLayer<PieDataset> {
 				}
 			} else {
 				// Just to show the "no data" text
-				final JFreeChart chart = createChart(createPieDataset(Collections.EMPTY_LIST), 1.0, 0.0);
+				final JFreeChart chart = createChart(createPieDataset(Collections.<Double>emptyList()), 1.0, 0.0);
 				chartList.add(chart);
 			}
 		}

--- a/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/internal/gradients/linear/LinearGradient.java
+++ b/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/internal/gradients/linear/LinearGradient.java
@@ -46,7 +46,7 @@ public class LinearGradient extends AbstractGradient<LinearGradientLayer> {
 			final View<? extends CyIdentifiable> grView) {
 		final LinearGradientLayer layer = createLayer();
 		
-		return layer != null ? Collections.singletonList(layer) : Collections.EMPTY_LIST;
+		return layer != null ? Collections.singletonList(layer) : Collections.emptyList();
 	}
 	
 	@Override

--- a/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/internal/gradients/radial/RadialGradient.java
+++ b/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/internal/gradients/radial/RadialGradient.java
@@ -50,7 +50,7 @@ public class RadialGradient extends AbstractGradient<RadialGradientLayer> {
 			final View<? extends CyIdentifiable> grView) {
 		final RadialGradientLayer layer = createLayer();
 		
-		return layer != null ? Collections.singletonList(layer) : Collections.EMPTY_LIST;
+		return layer != null ? Collections.singletonList(layer) : Collections.emptyList();
 	}
 	
 	@Override

--- a/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/graph/render/stateful/NodeDetails.java
+++ b/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/graph/render/stateful/NodeDetails.java
@@ -374,7 +374,7 @@ public class NodeDetails {
 
 	@SuppressWarnings("unchecked")
 	public Map<VisualProperty<CyCustomGraphics>, CustomGraphicsInfo> getCustomGraphics(final CyNode node) {
-		return Collections.EMPTY_MAP;
+		return Collections.emptyMap();
 	}
 	
 	/**

--- a/table-browser-impl/src/main/java/org/cytoscape/browser/internal/view/TableChooserCellRenderer.java
+++ b/table-browser-impl/src/main/java/org/cytoscape/browser/internal/view/TableChooserCellRenderer.java
@@ -42,7 +42,7 @@ public class TableChooserCellRenderer extends DefaultListCellRenderer {
 
 	@SuppressWarnings("unchecked")
 	TableChooserCellRenderer() {
-		this(Collections.EMPTY_MAP);
+		this(Collections.<CyTable, String>emptyMap());
 	}
 	
 	TableChooserCellRenderer(final Map<CyTable, String> tableToStringMap) {

--- a/vizmap-gui-impl/src/main/java/org/cytoscape/view/vizmap/gui/internal/view/VisualPropertySheet.java
+++ b/vizmap-gui-impl/src/main/java/org/cytoscape/view/vizmap/gui/internal/view/VisualPropertySheet.java
@@ -198,7 +198,7 @@ public class VisualPropertySheet extends JPanel{
 				@SuppressWarnings("unchecked")
 				public void mouseClicked(final MouseEvent e) {
 					if (!e.isShiftDown() || e.isControlDown()) // Deselect all items
-						setSelectedItems(Collections.EMPTY_SET);
+						setSelectedItems(Collections.<VisualPropertySheetItem<?>>emptySet());
 				}
 			});
 			

--- a/vizmap-gui-impl/src/main/java/org/cytoscape/view/vizmap/gui/internal/view/VizMapperMediator.java
+++ b/vizmap-gui-impl/src/main/java/org/cytoscape/view/vizmap/gui/internal/view/VizMapperMediator.java
@@ -940,7 +940,7 @@ public class VizMapperMediator extends Mediator implements LexiconStateChangedLi
 		final Set<View<CyNode>> selectedNodeViews = vmProxy.getSelectedNodeViews(curNetView);
 		final Set<View<CyEdge>> selectedEdgeViews = vmProxy.getSelectedEdgeViews(curNetView);
 		final Set<View<CyNetwork>> selectedNetViews = curNetView != null ?
-				Collections.singleton((View<CyNetwork>) curNetView) : Collections.EMPTY_SET;
+				Collections.singleton((View<CyNetwork>) curNetView) : Collections.emptySet();
 		final RenderingEngine<CyNetwork> engine = vizMapperMainPanel.getRenderingEngine();
 		
 		for (final VisualProperty<?> vp : vpList) {
@@ -1194,7 +1194,7 @@ public class VizMapperMediator extends Mediator implements LexiconStateChangedLi
 			updateLockedValues(vmProxy.getSelectedNodeViews(currentView), CyNode.class);
 			updateLockedValues(vmProxy.getSelectedEdgeViews(currentView), CyEdge.class);
 		} else {
-			updateLockedValues(Collections.EMPTY_SET, CyNetwork.class);
+			updateLockedValues(Collections.emptySet(), CyNetwork.class);
 		}
 	}
 	


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1596 - “Collections.emptyList(), emptyMap() and emptySet() should be used instead of Collections.EMPTY_LIST, EMPTY_MAP and EMPTY_SET”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1596
Please let me know if you have any questions.
Ayman Abdelghany.
