### PR TITLE
Useless parentheses around expressions should be removed

### DIFF
--- a/app-impl/src/main/java/org/cytoscape/app/internal/manager/App.java
+++ b/app-impl/src/main/java/org/cytoscape/app/internal/manager/App.java
@@ -255,7 +255,7 @@ public abstract class App {
 				&& WebQuerier.compareVersions(version, other.version) == 0) {
 
 			if (sha512Checksum != null && other.sha512Checksum != null) {
-				return (sha512Checksum.equalsIgnoreCase(other.sha512Checksum));
+				return sha512Checksum.equalsIgnoreCase(other.sha512Checksum);
 			}
 			
 			return true;

--- a/app-impl/src/main/java/org/cytoscape/app/internal/net/server/AppGetResponder.java
+++ b/app-impl/src/main/java/org/cytoscape/app/internal/net/server/AppGetResponder.java
@@ -163,7 +163,7 @@ public class AppGetResponder {
 			if (finishStatus.getType() == FinishStatus.Type.SUCCEEDED) {
 				installStatus = "success";
 			}
-			else if ((finishStatus.getType() == FinishStatus.Type.CANCELLED)) {
+			else if (finishStatus.getType() == FinishStatus.Type.CANCELLED) {
 				installStatus = "install-failed";
 				installError = "Install cancelled by user.";
 			}

--- a/core-task-impl/src/main/java/org/cytoscape/task/internal/layout/ApplyPreferredLayoutTask.java
+++ b/core-task-impl/src/main/java/org/cytoscape/task/internal/layout/ApplyPreferredLayoutTask.java
@@ -90,7 +90,7 @@ public class ApplyPreferredLayoutTask extends AbstractNetworkViewCollectionTask 
 			}
 
 			i++;
-			tm.setProgress((i / (double) viewCount));
+			tm.setProgress(i / (double) viewCount);
 		}
 
 		tm.setProgress(1.0);

--- a/core-task-impl/src/main/java/org/cytoscape/task/internal/vizmap/ApplyVisualStyleTask.java
+++ b/core-task-impl/src/main/java/org/cytoscape/task/internal/vizmap/ApplyVisualStyleTask.java
@@ -76,7 +76,7 @@ public class ApplyVisualStyleTask extends AbstractNetworkViewCollectionTask {
 			vmm.setVisualStyle(selected, view);
 
 			i++;
-			tm.setProgress((i / (double) viewCount));
+			tm.setProgress(i / (double) viewCount);
 		}
 
 		tm.setProgress(1.0);

--- a/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/impl/ArbitraryGraphicsCanvas.java
+++ b/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/impl/ArbitraryGraphicsCanvas.java
@@ -361,7 +361,7 @@ public class ArbitraryGraphicsCanvas extends DingCanvas implements ViewportChang
 	private void clearImage(Graphics2D image2D) {
 		if (img != null) {
 			// set color alpha based on opacity setting
-			int alpha = (m_isOpaque) ? 255 : 0;
+			int alpha = m_isOpaque ? 255 : 0;
 			Color backgroundColor = new Color(m_backgroundColor.getRed(), m_backgroundColor.getGreen(),
 			                                  m_backgroundColor.getBlue(), alpha);
 
@@ -398,7 +398,7 @@ public class ArbitraryGraphicsCanvas extends DingCanvas implements ViewportChang
 		}
 
 		public boolean equals(Component o1, Component o2) {
-			return (getComponentZOrder(o1) == getComponentZOrder(o2));
+			return getComponentZOrder(o1) == getComponentZOrder(o2);
 		}
 	}
 

--- a/layout-prefuse-impl/src/main/java/prefuse/util/force/AbstractForce.java
+++ b/layout-prefuse-impl/src/main/java/prefuse/util/force/AbstractForce.java
@@ -52,7 +52,7 @@ public abstract class AbstractForce implements Force {
      * @see prefuse.util.force.Force#getParameterCount()
      */
     public int getParameterCount() {
-        return ( params == null ? 0 : params.length );
+        return params == null ? 0 : params.length;
     }
 
     /**

--- a/table-import-impl/src/main/java/org/cytoscape/tableimport/internal/reader/AbstractLineParser.java
+++ b/table-import-impl/src/main/java/org/cytoscape/tableimport/internal/reader/AbstractLineParser.java
@@ -82,7 +82,7 @@ public abstract class AbstractLineParser {
 			return null;
 
 		final List<Object> list = new ArrayList<>();
-		final String[] parts = (s.replace("\"", "")).split(delimiter);
+		final String[] parts = s.replace("\"", "").split(delimiter);
 
 		for (String listItem : parts) {
 			try {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
Ayman Abdelghany.
