### PR TITLE
Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/app-impl/src/main/java/org/cytoscape/app/internal/net/server/OriginOptionsBeforeResponse.java
+++ b/app-impl/src/main/java/org/cytoscape/app/internal/net/server/OriginOptionsBeforeResponse.java
@@ -40,7 +40,7 @@ public class OriginOptionsBeforeResponse implements CyHttpBeforeResponse
 
     public OriginOptionsBeforeResponse(final String... allowedHeaders)
     {
-        final StringBuffer allowedHeadersBuffer = new StringBuffer("origin, accept");
+        final StringBuilder allowedHeadersBuffer = new StringBuilder("origin, accept");
         for (final String allowedHeader : allowedHeaders)
         {
             allowedHeadersBuffer.append(", ");

--- a/app-impl/src/main/java/org/cytoscape/app/internal/ui/CitationsDialog.java
+++ b/app-impl/src/main/java/org/cytoscape/app/internal/ui/CitationsDialog.java
@@ -173,7 +173,7 @@ class Article {
   }
 
   public String getAuthorsAsString() {
-    final StringBuffer buffer = new StringBuffer();
+    final StringBuilder buffer = new StringBuilder();
     for (int i = 0; i < authors.size(); i++) {
       buffer.append(authors.get(i));
       if (i != (authors.size() - 1))
@@ -213,7 +213,7 @@ class PubMedParser {
    * Takes a sequence of PubMed IDs and returns a URL for requesting article summaries from PubMed.
    */
   protected static String makeRequestURL(final Iterable<String> pmids) {
-    final StringBuffer buffer = new StringBuffer(REQUEST_URL_BASE);
+    final StringBuilder buffer = new StringBuilder(REQUEST_URL_BASE);
     final Iterator<String> iterator = pmids.iterator();
     while (iterator.hasNext()) {
       buffer.append(iterator.next());
@@ -376,7 +376,7 @@ class RetrieveTask implements Task {
     final PubMedParser pubMedParser = new PubMedParser();
     final Map<String,Article> articles = pubMedParser.retrieveArticles(pmids);
 
-    final StringBuffer buffer = new StringBuffer("<html>");
+    final StringBuilder buffer = new StringBuilder("<html>");
     formatArticleAsHtmlDefinition("Cytoscape", articles.get("Cytoscape"), buffer);
     buffer.append("<br><hr><br>");
     for (final String name : new TreeSet<String>(articles.keySet())) {
@@ -390,7 +390,7 @@ class RetrieveTask implements Task {
     textPane.setText(buffer.toString());
   }
 
-  private static void formatArticleAsHtmlDefinition(final String name, final Article article, final StringBuffer buffer) {
+  private static void formatArticleAsHtmlDefinition(final String name, final Article article, final StringBuilder buffer) {
     buffer.append("<dl><dt><b>");
     buffer.append(name);
     buffer.append("</b></dt>");

--- a/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/impl/cyannotator/annotations/GraphicsUtilities.java
+++ b/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/impl/cyannotator/annotations/GraphicsUtilities.java
@@ -217,7 +217,7 @@ class GraphicsUtilities {
 	}
 
 	static public String serializeShape(final Shape s) {
-        final StringBuffer buffer = new StringBuffer();
+        final StringBuilder buffer = new StringBuilder();
         final PathIterator i = s.getPathIterator(null);
         switch (i.getWindingRule()) {
             case PathIterator.WIND_EVEN_ODD:

--- a/filter-impl/src/main/java/org/cytoscape/filter/internal/filters/view/FilterMainPanel.java
+++ b/filter-impl/src/main/java/org/cytoscape/filter/internal/filters/view/FilterMainPanel.java
@@ -38,6 +38,7 @@ import java.awt.event.ComponentEvent;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.text.Collator;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -434,7 +435,7 @@ public class FilterMainPanel extends JPanel implements ActionListener,
 	 * "String" nor "numeric" will be excluded
 	 */
 	private List<String> getCyAttributesList(final CyNetwork network, final String pType) {
-		final Vector<String> attributeList = new Vector<String>();
+		final List<String> attributeList = new ArrayList<String>();
 		CyTable table = null;
 		
 		if (pType.equalsIgnoreCase("node") && network.getNodeCount() > 0) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149
Please let me know if you have any questions.
Ayman Abdelghany.
