### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/app-impl/src/main/java/org/cytoscape/app/internal/util/AppHelper.java
+++ b/app-impl/src/main/java/org/cytoscape/app/internal/util/AppHelper.java
@@ -7,7 +7,10 @@ import org.cytoscape.application.CyVersion;
 
 public class AppHelper {
 	private static Pattern COMPAT_VERSION_REGEX = Pattern.compile("^(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?([\\-\\.\\w]+)?$");
-	
+
+	private AppHelper() {
+	}
+
 	public static boolean isCompatible(final CyVersion cyVer, final String compatibleCytoscapeVersions) {
 		final String compatVersStr = compatibleCytoscapeVersions;
 		final String[] compatVers = compatVersStr.split(",");

--- a/app-impl/src/main/java/org/cytoscape/app/internal/util/DebugHelper.java
+++ b/app-impl/src/main/java/org/cytoscape/app/internal/util/DebugHelper.java
@@ -29,6 +29,9 @@ package org.cytoscape.app.internal.util;
  */
 public class DebugHelper {
 	private static boolean debug = false;
+
+	private DebugHelper() {
+	}
 //	private static boolean debug = true;
 	
 	public static void print(String message) {

--- a/app-impl/src/main/java/org/cytoscape/app/internal/util/Utils.java
+++ b/app-impl/src/main/java/org/cytoscape/app/internal/util/Utils.java
@@ -36,13 +36,16 @@ import org.cytoscape.application.swing.CySwingApplication;
 
 public class Utils {
 
+	private Utils() {
+	}
+
 	/*
-	 * dumbSplit splits a string on delimiter boundaries and doesn't try any
-	 * cute optimizations that the Java split would. For example, two
-	 * delimiters in a row are interpreted as delimiting an empty string.
-	 * So, this function returns one string for each delimiter and the
-	 * string that precedes any delimiter.
-	 */
+         * dumbSplit splits a string on delimiter boundaries and doesn't try any
+         * cute optimizations that the Java split would. For example, two
+         * delimiters in a row are interpreted as delimiting an empty string.
+         * So, this function returns one string for each delimiter and the
+         * string that precedes any delimiter.
+         */
 	public static String[] dumbSplit(String s, char delimiter) {
 		if (s == null) {
 			return null;

--- a/core-task-impl/src/main/java/org/cytoscape/task/internal/creation/GroupUtils.java
+++ b/core-task-impl/src/main/java/org/cytoscape/task/internal/creation/GroupUtils.java
@@ -52,6 +52,9 @@ public class GroupUtils {
 	private static final String NETWORK_SUID_ATTR = "__groupNetworks.SUID";
 	private static final String ISMETA_EDGE_ATTR = "__isMetaEdge";
 
+	private GroupUtils() {
+	}
+
 
 	public static Dimension getPosition(CyNetwork net, CyGroup group, Long suid, Class tableClass) {
 		CyTable table = group.getGroupNetwork().getTable(tableClass, CyNetwork.HIDDEN_ATTRS);

--- a/core-task-impl/src/main/java/org/cytoscape/task/internal/utils/DataUtils.java
+++ b/core-task-impl/src/main/java/org/cytoscape/task/internal/utils/DataUtils.java
@@ -38,7 +38,10 @@ import org.cytoscape.model.subnetwork.CySubNetwork;
 public class DataUtils {
 
 	public static final String PARENT_NETWORK_COLUMN = "__parentNetwork.SUID";
-	
+
+	private DataUtils() {
+	}
+
 	public static String getNodeName(CyTable table, CyNode node) {
 		String name = table.getRow(node.getSUID()).get(CyNetwork.NAME, String.class);
 		name += " (SUID: "+node.getSUID()+")";

--- a/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/customgraphics/CustomGraphicsPositionCalculator.java
+++ b/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/customgraphics/CustomGraphicsPositionCalculator.java
@@ -56,8 +56,11 @@ public class CustomGraphicsPositionCalculator {
 		
 		DISPLACEMENT_MAP.put(Position.EAST,  new Float[]{0.5f, 0f});
 	}
-	
-	
+
+	private CustomGraphicsPositionCalculator() {
+	}
+
+
 	/**
 	 * Creates new custom graphics in new location
 	 */

--- a/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/customgraphics/CustomGraphicsUtil.java
+++ b/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/customgraphics/CustomGraphicsUtil.java
@@ -28,6 +28,9 @@ import java.awt.Image;
 
 public class CustomGraphicsUtil {
 
+	private CustomGraphicsUtil() {
+	}
+
 	public static Image getResizedImage(Image original, final Integer w, final Integer h, boolean keepAspectRatio) {
 		if(original == null)
 			throw new IllegalArgumentException("Original image cannot be null.");

--- a/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/customgraphics/ImageUtil.java
+++ b/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/customgraphics/ImageUtil.java
@@ -34,7 +34,10 @@ import java.awt.image.WritableRaster;
 import java.util.Hashtable;
 
 public class ImageUtil {
-	
+
+
+	private ImageUtil() {
+	}
 
 	public static BufferedImage toBufferedImage(final Image image) throws InterruptedException {
 		if (image instanceof BufferedImage)

--- a/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/icon/VisualPropertyIconFactory.java
+++ b/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/icon/VisualPropertyIconFactory.java
@@ -46,8 +46,11 @@ import org.cytoscape.view.presentation.property.values.NodeShape;
  * Static factory for icons.
  *
  */
-public class VisualPropertyIconFactory {	
-	
+public class VisualPropertyIconFactory {
+
+	private VisualPropertyIconFactory() {
+	}
+
 	public static <V> Icon createIcon(V value, int w, int h) {
 		if(value == null)
 			return null;

--- a/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/impl/cyannotator/annotations/GraphicsUtilities.java
+++ b/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/impl/cyannotator/annotations/GraphicsUtilities.java
@@ -92,6 +92,9 @@ class GraphicsUtilities {
 		ArrowType.TRIANGLE.arrowName(), 
 		ArrowType.TSHAPE.arrowName());
 
+	private GraphicsUtilities() {
+	}
+
 	static public Shape getShape(String shapeName, double x, double y, double width, double height) {
 		ShapeType shapeType = getShapeType(shapeName);
 		switch(shapeType) {

--- a/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/internal/charts/ViewUtils.java
+++ b/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/internal/charts/ViewUtils.java
@@ -10,6 +10,9 @@ import javax.swing.ImageIcon;
 
 public class ViewUtils {
 
+	private ViewUtils() {
+	}
+
 	public static ImageIcon resizeIcon(final ImageIcon icon, int width, int height) {
 		final Image img = icon.getImage().getScaledInstance(width, height, Image.SCALE_AREA_AVERAGING);
 		final BufferedImage bi = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);

--- a/ding-impl/ding-presentation-impl/src/test/java/org/cytoscape/util/intr/BitSetPerformance.java
+++ b/ding-impl/ding-presentation-impl/src/test/java/org/cytoscape/util/intr/BitSetPerformance.java
@@ -37,6 +37,9 @@ import java.util.BitSet;
  */
  // TODO Turn into JUnit tests
 public class BitSetPerformance {
+	private BitSetPerformance() {
+	}
+
 	/**
 	 * This test is analagous to
 	 * cytoscape.intr.util.test.MinIntHeapPerformance, only

--- a/ding-impl/ding-presentation-impl/src/test/java/org/cytoscape/util/intr/IntBTreeConstructionTuner.java
+++ b/ding-impl/ding-presentation-impl/src/test/java/org/cytoscape/util/intr/IntBTreeConstructionTuner.java
@@ -35,6 +35,9 @@ import java.io.InputStream;
  */
  // TODO Turn into JUnit tests
 public class IntBTreeConstructionTuner {
+	private IntBTreeConstructionTuner() {
+	}
+
 	/**
 	 *  DOCUMENT ME!
 	 *

--- a/ding-impl/ding-presentation-impl/src/test/java/org/cytoscape/util/intr/IntBTreeQueryTuner.java
+++ b/ding-impl/ding-presentation-impl/src/test/java/org/cytoscape/util/intr/IntBTreeQueryTuner.java
@@ -36,6 +36,9 @@ import java.io.InputStream;
  */
  // TODO Turn into JUnit tests
 public class IntBTreeQueryTuner {
+	private IntBTreeQueryTuner() {
+	}
+
 	/**
 	 *  DOCUMENT ME!
 	 *

--- a/filter-impl/src/main/java/org/cytoscape/filter/internal/filters/util/FilterUtil.java
+++ b/filter-impl/src/main/java/org/cytoscape/filter/internal/filters/util/FilterUtil.java
@@ -45,7 +45,10 @@ public class FilterUtil {
 	public static final String SESSION_FILE_NAME = "session_filters.props";
 	public static final String DYNAMIC_FILTER_THRESHOLD = "dynamicFilterThreshold";
 	public static final int DEFAULT_DYNAMIC_FILTER_THRESHOLD = 1000;
-	
+
+	private FilterUtil() {
+	}
+
 	// do selection on given network
 	public static void doSelection(CompositeFilter pFilter, CyApplicationManager applicationManager) {
 //		// TODO: What do we do about CyInit*?

--- a/filter-impl/src/main/java/org/cytoscape/filter/internal/filters/util/SelectUtil.java
+++ b/filter-impl/src/main/java/org/cytoscape/filter/internal/filters/util/SelectUtil.java
@@ -35,6 +35,9 @@ import org.cytoscape.model.CyRow;
 import org.cytoscape.model.CyTableUtil;
 
 public class SelectUtil {
+	private SelectUtil() {
+	}
+
 	public static void unselectAllNodes(CyNetwork network) {
 		setSelectedState(network, CyTableUtil.getNodesInState(network, CyNetwork.SELECTED, true), false);
 	}

--- a/filter-impl/src/main/java/org/cytoscape/filter/internal/filters/util/ServicesUtil.java
+++ b/filter-impl/src/main/java/org/cytoscape/filter/internal/filters/util/ServicesUtil.java
@@ -62,4 +62,7 @@ public class ServicesUtil {
 	public static CyLayoutAlgorithmManager cyLayoutsServiceRef;
 	public static CyVersion cytoscapeVersionService;
 	public static CyApplicationConfiguration cyApplicationConfigurationServiceRef;
+
+	private ServicesUtil() {
+	}
 }

--- a/filter-impl/src/main/java/org/cytoscape/filter/internal/filters/util/VisualPropertyUtil.java
+++ b/filter-impl/src/main/java/org/cytoscape/filter/internal/filters/util/VisualPropertyUtil.java
@@ -30,6 +30,9 @@ import org.cytoscape.view.model.VisualProperty;
 import org.cytoscape.view.model.Visualizable;
 
 public class VisualPropertyUtil {
+	private VisualPropertyUtil() {
+	}
+
 	@SuppressWarnings("unchecked")
 	public static <T> T get(VisualLexicon lexicon, View<?> view, String id, VisualProperty<Visualizable> root, Class<T> type) {
 		for (VisualProperty<?> property : lexicon.getAllDescendants(root)) {

--- a/filter-impl/src/main/java/org/cytoscape/filter/internal/quickfind/util/CyAttributesUtil.java
+++ b/filter-impl/src/main/java/org/cytoscape/filter/internal/quickfind/util/CyAttributesUtil.java
@@ -42,6 +42,9 @@ import org.cytoscape.model.CyTable;
  * @author Ethan Cerami
  */
 public class CyAttributesUtil {
+	private CyAttributesUtil() {
+	}
+
 	/**
 	 * Regardless of attribute type, this method will always return attribute
 	 * values as an array of String objects.  For example, given an attribute of

--- a/filter-impl/src/main/java/org/cytoscape/filter/internal/widgets/autocomplete/index/IndexFactory.java
+++ b/filter-impl/src/main/java/org/cytoscape/filter/internal/widgets/autocomplete/index/IndexFactory.java
@@ -31,6 +31,9 @@ package org.cytoscape.filter.internal.widgets.autocomplete.index;
  * @author Ethan Cerami.
  */
 public class IndexFactory {
+	private IndexFactory() {
+	}
+
 	/**
 	 * Gets the default implementation of the TextIndex interface.
 	 *

--- a/filter-impl/src/main/java/org/cytoscape/filter/internal/widgets/autocomplete/view/ComboBoxFactory.java
+++ b/filter-impl/src/main/java/org/cytoscape/filter/internal/widgets/autocomplete/view/ComboBoxFactory.java
@@ -36,6 +36,9 @@ import org.cytoscape.filter.internal.widgets.autocomplete.index.TextIndex;
  * @author Ethan Cerami
  */
 public class ComboBoxFactory {
+	private ComboBoxFactory() {
+	}
+
 	/**
 	 * Creates a new TextIndex Combo Box.
 	 *

--- a/filter2-impl/src/main/java/org/cytoscape/filter/internal/ModelUtil.java
+++ b/filter2-impl/src/main/java/org/cytoscape/filter/internal/ModelUtil.java
@@ -7,6 +7,9 @@ import org.cytoscape.filter.model.NamedTransformer;
 import org.cytoscape.filter.model.Transformer;
 
 public class ModelUtil {
+	private ModelUtil() {
+	}
+
 	public static NamedTransformer<?, ?> createNamedTransformer(String name, Transformer<?, ?>... transformers) {
 		return new NamedTransformerImpl(name, transformers);
 	}

--- a/filter2-impl/src/main/java/org/cytoscape/filter/internal/view/ViewUtil.java
+++ b/filter2-impl/src/main/java/org/cytoscape/filter/internal/view/ViewUtil.java
@@ -32,7 +32,10 @@ public class ViewUtil {
 	public static final Border COMPOSITE_PANEL_BORDER = BorderFactory.createCompoundBorder(
 			new DashedBorder(UIManager.getColor("Separator.foreground"), 3),
 			BorderFactory.createEmptyBorder(INTERNAL_VERTICAL_PADDING, 0, INTERNAL_VERTICAL_PADDING, 0));
-	
+
+	private ViewUtil() {
+	}
+
 	public static void configureFilterView(JComponent component) {
 		component.setBackground(UNSELECTED_BACKGROUND_COLOR);
 		component.setBorder(COMPOSITE_PANEL_BORDER);

--- a/group-impl/src/main/java/org/cytoscape/group/internal/ModelUtils.java
+++ b/group-impl/src/main/java/org/cytoscape/group/internal/ModelUtils.java
@@ -50,6 +50,9 @@ import org.cytoscape.model.subnetwork.CySubNetwork;
  */
 public class ModelUtils {
 
+	private ModelUtils() {
+	}
+
 	public static void createColumnIfNeeded(CyTable table, String name, Class type) {
 		if (table.getColumn(name) == null)
 			table.createColumn(name, type, false);

--- a/group-impl/src/main/java/org/cytoscape/group/internal/view/ViewUtils.java
+++ b/group-impl/src/main/java/org/cytoscape/group/internal/view/ViewUtils.java
@@ -78,6 +78,9 @@ public class ViewUtils {
 	private static final double Z_OFFSET = -100.0; // Offset for group nodes
 	private static final int COMPOUND_NODE_TRANSPARENCY = 50;
 
+	private ViewUtils() {
+	}
+
 	public static void applyStyle(final Collection<? extends CyIdentifiable> elements,
 	                              final Collection<CyNetworkView> networkViews,
 	                              final VisualMappingManager cyStyleManager) {

--- a/io-impl/impl/src/main/java/org/cytoscape/io/internal/read/CopyInputStream.java
+++ b/io-impl/impl/src/main/java/org/cytoscape/io/internal/read/CopyInputStream.java
@@ -31,6 +31,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
 public class CopyInputStream {
+	private CopyInputStream() {
+	}
+
 	/**
 	 * @param is The InputStream to be copied.
 	 * @param kb The number of kilobytes to read. For example, 

--- a/io-impl/impl/src/main/java/org/cytoscape/io/internal/read/xgmml/handler/XGMMLParseUtil.java
+++ b/io-impl/impl/src/main/java/org/cytoscape/io/internal/read/xgmml/handler/XGMMLParseUtil.java
@@ -30,7 +30,10 @@ import java.util.regex.Pattern;
 public class XGMMLParseUtil {
 
 	static final Pattern XLINK_PATTERN = Pattern.compile(".*#(-?\\d+)");
-	
+
+	private XGMMLParseUtil() {
+	}
+
 	public static double parseDocumentVersion(String value) {
 		double version = 0.0;
     	

--- a/io-impl/impl/src/main/java/org/cytoscape/io/internal/util/session/SessionUtil.java
+++ b/io-impl/impl/src/main/java/org/cytoscape/io/internal/util/session/SessionUtil.java
@@ -65,7 +65,10 @@ public class SessionUtil {
 	private static boolean readingSessionFile; // TODO: delete it and find a better solution!
 	
 	private static final Logger logger = LoggerFactory.getLogger(SessionUtil.class);
-	
+
+	private SessionUtil() {
+	}
+
 	public static String escape(String text) {
 		try {
 			return URLEncoder.encode(text, "UTF-8").replace("-", "%2D");

--- a/swing-application-impl/src/main/java/org/cytoscape/internal/view/MacFullScreenEnabler.java
+++ b/swing-application-impl/src/main/java/org/cytoscape/internal/view/MacFullScreenEnabler.java
@@ -29,6 +29,9 @@ import java.awt.Window;
 import com.apple.eawt.FullScreenUtilities;
 
 public class MacFullScreenEnabler {
+	private MacFullScreenEnabler() {
+	}
+
 	public static void setEnabled(Window window, boolean b) {
 		FullScreenUtilities.setWindowCanFullScreen(window, true);
 	}

--- a/table-browser-impl/src/main/java/org/cytoscape/browser/internal/util/TableBrowserUtil.java
+++ b/table-browser-impl/src/main/java/org/cytoscape/browser/internal/util/TableBrowserUtil.java
@@ -39,6 +39,9 @@ public final class TableBrowserUtil {
 
 	private static final int EOF = -1;
 
+	private TableBrowserUtil() {
+	}
+
 	/**
 	 *  Creates a Map with the CyColumn names and their types as mapped to the types used by attribute equations.
 	 *  Types (and associated names) not used by attribute equations are omitted.

--- a/table-import-impl/src/main/java/org/cytoscape/tableimport/internal/util/OntologyDAGManager.java
+++ b/table-import-impl/src/main/java/org/cytoscape/tableimport/internal/util/OntologyDAGManager.java
@@ -36,7 +36,10 @@ import org.cytoscape.model.CyNetwork;
 public class OntologyDAGManager {
 	
 	private static final Map<String, CyNetwork> dagMap = new HashMap<String, CyNetwork>();
-	
+
+	private OntologyDAGManager() {
+	}
+
 	public static CyNetwork getOntologyDAG(final String ontologyID) {
 		return dagMap.get(ontologyID);
 	}

--- a/table-import-impl/src/main/java/org/cytoscape/tableimport/internal/util/URLUtil.java
+++ b/table-import-impl/src/main/java/org/cytoscape/tableimport/internal/util/URLUtil.java
@@ -50,6 +50,9 @@ public class URLUtil {
 
 	private static int msConnectionTimeout = 2000;
 
+	private URLUtil() {
+	}
+
 	/**
 	 * Gets the an input stream given a URL.
 	 * 

--- a/vizmap-gui-impl/src/main/java/org/cytoscape/view/vizmap/gui/internal/util/NumberConverter.java
+++ b/vizmap-gui-impl/src/main/java/org/cytoscape/view/vizmap/gui/internal/util/NumberConverter.java
@@ -25,7 +25,10 @@ package org.cytoscape.view.vizmap.gui.internal.util;
  */
 
 public final class NumberConverter {
-	
+
+	private NumberConverter() {
+	}
+
 	@SuppressWarnings("unchecked")
 	public static final <T> T convert(final Class<T> type, final Number value) {
 		T converted = null;

--- a/vizmap-impl/impl/src/main/java/org/cytoscape/view/vizmap/internal/mappings/ColorUtil.java
+++ b/vizmap-impl/impl/src/main/java/org/cytoscape/view/vizmap/internal/mappings/ColorUtil.java
@@ -45,6 +45,9 @@ public class ColorUtil {
 		buildColorCodeTable(ColorUtil.class.getClassLoader().getResource(COLOR_CODE_RESOURCE));
 	}
 
+	private ColorUtil() {
+	}
+
 	private static void buildColorCodeTable(final URL resourceURL) {
 		BufferedReader bufRd = null;
 		String line;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.
