### PR TITLE
graphml: add subgraphs to groups, and render them as compound nodes

### DIFF
--- a/graphml-impl/pom.xml
+++ b/graphml-impl/pom.xml
@@ -43,6 +43,11 @@
 		<!-- Cytoscape Core API -->
 		<dependency>
 			<groupId>org.cytoscape</groupId>
+			<artifactId>group-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.cytoscape</groupId>
 			<artifactId>io-api</artifactId>
 			<scope>provided</scope>
 		</dependency>
@@ -68,6 +73,19 @@
 			<groupId>org.cytoscape</groupId>
 			<artifactId>event-api</artifactId>
 			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.cytoscape</groupId>
+			<artifactId>group-impl</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.cytoscape</groupId>
+			<artifactId>group-impl</artifactId>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/graphml-impl/src/main/java/org/cytoscape/io/internal/CyActivator.java
+++ b/graphml-impl/src/main/java/org/cytoscape/io/internal/CyActivator.java
@@ -37,6 +37,7 @@ import org.cytoscape.model.CyNetworkFactory;
 import org.cytoscape.model.CyNetworkManager;
 import org.cytoscape.model.subnetwork.CyRootNetworkManager;
 import org.cytoscape.service.util.AbstractCyActivator;
+import org.cytoscape.service.util.CyServiceRegistrar;
 import org.cytoscape.view.layout.CyLayoutAlgorithmManager;
 import org.osgi.framework.BundleContext;
 
@@ -51,6 +52,7 @@ public class CyActivator extends AbstractCyActivator {
 	@Override
 	public void start(BundleContext bc) {
 		// Import required Services
+		final CyServiceRegistrar serviceRegistrar = getService(bc, CyServiceRegistrar.class);
 		StreamUtil streamUtilRef = getService(bc, StreamUtil.class);
 		CyLayoutAlgorithmManager cyLayoutsServiceRef = getService(bc, CyLayoutAlgorithmManager.class);
 		CyNetworkFactory cyNetworkFactoryServiceRef = getService(bc, CyNetworkFactory.class);
@@ -63,7 +65,7 @@ public class CyActivator extends AbstractCyActivator {
 		
 		GraphMLReaderFactory graphMLReaderFactory = new GraphMLReaderFactory(graphMLFilter, cyLayoutsServiceRef,
 				cyApplicationManagerServiceRef, cyNetworkFactoryServiceRef, cyNetworkManager,
-				cyRootNetworkFactoryServiceRef);
+				cyRootNetworkFactoryServiceRef, serviceRegistrar);
 		
 		GraphMLNetworkWriterFactory graphMLNetworkWriterFactory = new GraphMLNetworkWriterFactory(graphMLFilter);
 

--- a/graphml-impl/src/main/java/org/cytoscape/io/internal/read/graphml/GraphMLReaderFactory.java
+++ b/graphml-impl/src/main/java/org/cytoscape/io/internal/read/graphml/GraphMLReaderFactory.java
@@ -32,6 +32,7 @@ import org.cytoscape.io.read.AbstractInputStreamTaskFactory;
 import org.cytoscape.model.CyNetworkFactory;
 import org.cytoscape.model.CyNetworkManager;
 import org.cytoscape.model.subnetwork.CyRootNetworkManager;
+import org.cytoscape.service.util.CyServiceRegistrar;
 import org.cytoscape.view.layout.CyLayoutAlgorithmManager;
 import org.cytoscape.work.TaskIterator;
 
@@ -41,6 +42,7 @@ public class GraphMLReaderFactory extends AbstractInputStreamTaskFactory {
 	private final CyNetworkFactory cyNetworkFactory;
 	private final CyRootNetworkManager cyRootNetworkFactory;
 	private final CyNetworkManager cyNetworkManager;
+	private final CyServiceRegistrar cyServiceRegistrar;
 
 	private final CyLayoutAlgorithmManager layouts;
 
@@ -49,18 +51,20 @@ public class GraphMLReaderFactory extends AbstractInputStreamTaskFactory {
 								final CyApplicationManager cyApplicationManager,
 								final CyNetworkFactory cyNetworkFactory,
 								final CyNetworkManager cyNetworkManager,
-								final CyRootNetworkManager cyRootNetworkFactory) {
+								final CyRootNetworkManager cyRootNetworkFactory,
+								final CyServiceRegistrar cyServiceRegistrar) {
 		super(filter);
 		this.cyApplicationManager = cyApplicationManager;
 		this.cyNetworkFactory = cyNetworkFactory;
 		this.cyRootNetworkFactory = cyRootNetworkFactory;
 		this.layouts = layouts;
 		this.cyNetworkManager = cyNetworkManager;
+		this.cyServiceRegistrar = cyServiceRegistrar;
 	}
 
 	@Override
 	public TaskIterator createTaskIterator(InputStream inputStream, String inputName) {
 		return new TaskIterator(new GraphMLReader(inputStream, layouts, cyApplicationManager, cyNetworkFactory,
-				cyNetworkManager, cyRootNetworkFactory));
+				cyNetworkManager, cyRootNetworkFactory, cyServiceRegistrar));
 	}
 }

--- a/graphml-impl/src/test/java/org/cytoscape/data/reader/graphml/GraphMLReaderTest.java
+++ b/graphml-impl/src/test/java/org/cytoscape/data/reader/graphml/GraphMLReaderTest.java
@@ -35,6 +35,8 @@ import java.io.InputStream;
 import org.cytoscape.application.CyApplicationManager;
 import org.cytoscape.application.NetworkViewRenderer;
 import org.cytoscape.ding.NetworkViewTestSupport;
+import org.cytoscape.group.CyGroupFactory;
+import org.cytoscape.group.GroupTestSupport;
 import org.cytoscape.io.internal.read.graphml.GraphMLReader;
 import org.cytoscape.model.CyColumn;
 import org.cytoscape.model.CyEdge;
@@ -45,6 +47,7 @@ import org.cytoscape.model.CyNode;
 import org.cytoscape.model.NetworkTestSupport;
 import org.cytoscape.model.internal.NetworkNameSetListener;
 import org.cytoscape.model.subnetwork.CyRootNetworkManager;
+import org.cytoscape.service.util.CyServiceRegistrar;
 import org.cytoscape.view.layout.CyLayoutAlgorithmManager;
 import org.cytoscape.view.model.CyNetworkViewFactory;
 import org.cytoscape.work.TaskMonitor;
@@ -56,6 +59,7 @@ import org.mockito.MockitoAnnotations;
 
 public class GraphMLReaderTest {
 	
+	private GroupTestSupport groupTestSupport;
 	private NetworkTestSupport testSupport;
 	private NetworkViewTestSupport nvts;
 	private CyNetworkFactory netFactory;
@@ -67,11 +71,13 @@ public class GraphMLReaderTest {
 	@Mock private NetworkViewRenderer netViewRenderer;
 	@Mock private CyLayoutAlgorithmManager layouts;
 	@Mock private TaskMonitor tm;
+	@Mock private CyServiceRegistrar serviceRegistrar;
 	
 	@Before
 	public void setUp() throws Exception {
 		MockitoAnnotations.initMocks(this);
 		
+		groupTestSupport = new GroupTestSupport();
 		testSupport = new NetworkTestSupport();
 		nvts = new NetworkViewTestSupport();
 		
@@ -82,6 +88,8 @@ public class GraphMLReaderTest {
 		
 		when(netViewRenderer.getNetworkViewFactory()).thenReturn(viewFactory);
 		when(appManager.getDefaultNetworkViewRenderer()).thenReturn(netViewRenderer);
+		
+		when(serviceRegistrar.getService(CyGroupFactory.class)).thenReturn(groupTestSupport.getGroupFactory());
 	}
 
 	@After
@@ -92,7 +100,7 @@ public class GraphMLReaderTest {
 	public void testReadSimpleGraph() throws Exception {
 		File file = new File("src/test/resources/testGraph1.xml");
 		InputStream stream = file.toURI().toURL().openStream();
-		GraphMLReader reader = new GraphMLReader(stream, layouts, appManager, netFactory, networkManager, rootFactory);
+		GraphMLReader reader = new GraphMLReader(stream, layouts, appManager, netFactory, networkManager, rootFactory, serviceRegistrar);
 		assertNotNull(reader);
 		reader.run(tm);
 		final CyNetwork[] networks = reader.getNetworks();
@@ -107,7 +115,7 @@ public class GraphMLReaderTest {
 	public void testReadAttrGraph() throws Exception {
 		File file = new File("src/test/resources/simpleWithAttributes.xml");
 		InputStream stream = file.toURI().toURL().openStream();
-		GraphMLReader reader = new GraphMLReader(stream, layouts, appManager, netFactory, networkManager, rootFactory);
+		GraphMLReader reader = new GraphMLReader(stream, layouts, appManager, netFactory, networkManager, rootFactory, serviceRegistrar);
 		assertNotNull(reader);
 		reader.run(tm);
 		final CyNetwork[] networks = reader.getNetworks();
@@ -163,7 +171,7 @@ public class GraphMLReaderTest {
 	public void testReadAttedOutput() throws Exception {
 		File file = new File("src/test/resources/atted.graphml");
 		InputStream stream = file.toURI().toURL().openStream();
-		GraphMLReader reader = new GraphMLReader(stream, layouts, appManager, netFactory, networkManager, rootFactory);
+		GraphMLReader reader = new GraphMLReader(stream, layouts, appManager, netFactory, networkManager, rootFactory, serviceRegistrar);
 		assertNotNull(reader);
 		reader.run(tm);
 		final CyNetwork[] networks = reader.getNetworks();
@@ -185,7 +193,7 @@ public class GraphMLReaderTest {
 	public void testReadNestedSubgraphs() throws Exception {
 		File file = new File("src/test/resources/nested.xml");
 		InputStream stream = file.toURI().toURL().openStream();
-		GraphMLReader reader = new GraphMLReader(stream, layouts, appManager, netFactory, networkManager, rootFactory);
+		GraphMLReader reader = new GraphMLReader(stream, layouts, appManager, netFactory, networkManager, rootFactory, serviceRegistrar);
 		assertNotNull(reader);
 		reader.run(tm);
 		final CyNetwork[] networks = reader.getNetworks();
@@ -196,7 +204,8 @@ public class GraphMLReaderTest {
 		for(CyNode node: rootNetwork.getNodeList())
 			System.out.println("In root network: " + rootNetwork.getRow(node).get(CyNetwork.NAME, String.class));
 		
-		assertEquals(11, rootNetwork.getNodeCount());
+		// 11 nodes + 3 groups
+		assertEquals(14, rootNetwork.getNodeCount());
 		assertEquals(12, rootNetwork.getEdgeCount());
 		
 		final CyNetwork child1 = networks[1];
@@ -216,7 +225,7 @@ public class GraphMLReaderTest {
 	public void testReadNestedSubgraphs2() throws Exception {
 		File file = new File("src/test/resources/nested2.xml");
 		InputStream stream = file.toURI().toURL().openStream();
-		GraphMLReader reader = new GraphMLReader(stream, layouts, appManager, netFactory, networkManager, rootFactory);
+		GraphMLReader reader = new GraphMLReader(stream, layouts, appManager, netFactory, networkManager, rootFactory, serviceRegistrar);
 		assertNotNull(reader);
 		reader.run(tm);
 		final CyNetwork[] networks = reader.getNetworks();
@@ -227,7 +236,8 @@ public class GraphMLReaderTest {
 		for(CyNode node: rootNetwork.getNodeList())
 			System.out.println("In root network: " + rootNetwork.getRow(node).get(CyNetwork.NAME, String.class));
 		
-		assertEquals(8, rootNetwork.getNodeCount());
+		// 8 nodes + 3 groups
+		assertEquals(11, rootNetwork.getNodeCount());
 		assertEquals(10, rootNetwork.getEdgeCount());
 		
 		final CyNetwork child1 = networks[1];


### PR DESCRIPTION
Reference: compound nodes discussion on https://groups.google.com/forum/#!topic/cytoscape-helpdesk/rcVl6ohBmJ4

* I tested mostly with the nested graph from http://graphml.graphdrawing.org/primer/graphml-primer.html#NHP 
* Tested and developed with 3.6.1 on OSX (but this PR is rebased against develop). I'd test against develop... but the dependencies all seem to take forever to download so I killed the build and just used the distribution

Honestly, the compound node stuff is a bit of a hack, but I couldn't figure out a better way to do it. If you don't display it as a compound node, the group nodes are just floating and that's no good. If there's a suggestion for a 'supported' way of doing this, I'm willing to give it a try (though I don't think I'll have time until next week).

As mentioned on the mailing list, one of the problems is that I'm only able to add groups to the root network. I created a variation that added groups at all subgraphs, but it fails in various ways when trying to trigger the compound node display code (if someone is interested in that, I can push it to a separate branch).