### PR TITLE
Cytoscape 12553

### DIFF
--- a/search-impl/src/main/java/org/cytoscape/search/internal/EnhancedSearchIndex.java
+++ b/search-impl/src/main/java/org/cytoscape/search/internal/EnhancedSearchIndex.java
@@ -29,6 +29,7 @@ package org.cytoscape.search.internal;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.Callable;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Document;
@@ -48,9 +49,23 @@ import org.cytoscape.search.internal.util.EnhancedSearchUtils;
 import org.cytoscape.work.TaskMonitor;
 
 
-public class EnhancedSearchIndex {
-	
-	private EnhancedSearchIndex() { }
+public class EnhancedSearchIndex implements Callable {
+
+	private CyNetwork network;
+	private TaskMonitor taskMonitor;
+	protected EnhancedSearchIndex(CyNetwork network, TaskMonitor taskMonitor) {
+		this.network = network;
+		this.taskMonitor = taskMonitor;
+	}
+
+	/**
+	 * Lets search be called from an ExecutorService
+	 */
+	@Override
+	public RAMDirectory call() throws Exception {
+		RAMDirectory idx = EnhancedSearchIndex.buildIndex(this.network, this.taskMonitor);
+		return idx;
+	}
 	
 
 	public static RAMDirectory buildIndex(CyNetwork network, TaskMonitor taskMonitor) {

--- a/search-impl/src/main/java/org/cytoscape/search/internal/EnhancedSearchQuery.java
+++ b/search-impl/src/main/java/org/cytoscape/search/internal/EnhancedSearchQuery.java
@@ -91,21 +91,23 @@ public class EnhancedSearchQuery {
 		// CustomMultiFieldQueryParser is used to support range queries on numerical attribute fields.
 		QueryParser queryParser = new CustomMultiFieldQueryParser(attFields, new CaseInsensitiveWhitespaceAnalyzer());
 
-		SearchResults results;
 		try {
 			// Execute query
 			Query query = queryParser.parse(queryString);
 			IdentifiersCollector hitCollector = new IdentifiersCollector(searcher);
 			searcher.search(query, hitCollector);		    
-			results = SearchResults.results(hitCollector.getNodeHits(), hitCollector.getEdgeHits());
+			this.results = SearchResults.results(hitCollector.getNodeHits(), hitCollector.getEdgeHits());
 		} catch (ParseException pe) {
-			//int column = pe.currentToken.next.beginColumn;
-			results = SearchResults.syntaxError();
+			if (pe.getMessage() != null && pe.getMessage().endsWith("too many boolean clauses")){
+				this.results = SearchResults.syntaxError("At " + queryString.length() + " characters query string is too large");
+			} else {
+				this.results = SearchResults.syntaxError();
+			}
+			logger.error(pe.getMessage(), pe);
 		} catch (Exception e) {
-			results = SearchResults.fatalError();
+			this.results = SearchResults.fatalError();
 			logger.error(e.getMessage(), e);
 		}
-		this.results = results;
 	}
 	
 	public SearchResults getResults() {

--- a/search-impl/src/main/java/org/cytoscape/search/internal/EnhancedSearchQuery.java
+++ b/search-impl/src/main/java/org/cytoscape/search/internal/EnhancedSearchQuery.java
@@ -3,6 +3,7 @@ package org.cytoscape.search.internal;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Callable;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexReader;
@@ -47,18 +48,30 @@ import org.slf4j.LoggerFactory;
  * #L%
  */
 
-public class EnhancedSearchQuery {
-	
+public class EnhancedSearchQuery implements Callable {
+
 	private static final Logger logger = LoggerFactory.getLogger(CyUserLog.NAME);
 	
 	private final RAMDirectory idx;
 	private final CyNetwork network;
 	private SearchResults results;
 	private Searcher searcher;
+	private final String query;
 
-	public EnhancedSearchQuery(CyNetwork network, RAMDirectory index) {
+	public EnhancedSearchQuery(CyNetwork network, RAMDirectory index, final String query) {
 		this.network = network;
 		this.idx = index;
+		this.query = query;
+	}
+
+	/**
+	 * Lets query be called from an ExecutorService
+	 * @return results of query
+	 */
+	@Override
+	public SearchResults call() throws Exception {
+		this.executeQuery(query);
+		return results;
 	}
 
 	public void executeQuery(String queryString) {

--- a/search-impl/src/main/java/org/cytoscape/search/internal/IndexAndSearchTask.java
+++ b/search-impl/src/main/java/org/cytoscape/search/internal/IndexAndSearchTask.java
@@ -77,7 +77,7 @@ public class IndexAndSearchTask extends AbstractNetworkTask implements Observabl
 
 		if (query.length() > IndexAndSearchTask.MAX_QUERY_LEN) {
 			this.results = SearchResults.syntaxError("At " + query.length() + " characters query string is too large");
-			logger.error(this.results.getErrorMessage());
+			logger.error(this.results.getMessage());
 			return;
 		}
 

--- a/search-impl/src/main/java/org/cytoscape/search/internal/SearchResults.java
+++ b/search-impl/src/main/java/org/cytoscape/search/internal/SearchResults.java
@@ -10,33 +10,47 @@ public class SearchResults {
 	}
 	
 	private final Status status;
-	private final String errorMessage;
+	private final String message;
 	private final List<String> nodeHits;
 	private final List<String> edgeHits;
 
 	
-	private SearchResults(Status status, final String errorMessage, List<String> nodeHits, List<String> edgeHits) {
+	private SearchResults(Status status, final String message, List<String> nodeHits, List<String> edgeHits) {
 		this.status = status;
-		this.errorMessage = errorMessage;
 		this.nodeHits = nodeHits == null ? Collections.<String>emptyList() : nodeHits;
 		this.edgeHits = edgeHits == null ? Collections.<String>emptyList() : edgeHits;
-	}
-	
-	
-	public static SearchResults syntaxError() {
-		return new SearchResults(Status.ERROR_SYNTAX, null, null, null);
+		if (this.isError() == false && message == null) {
+			int edges = this.getEdgeHitCount();
+			int nodes = this.getNodeHitCount();
+			if(nodes == 1 && edges == 1) {
+				this.message = "Selected 1 node and 1 edge";
+			} else if(nodes == 1 && edges != 1) {
+				this.message = "Selected 1 node and " + edges + " edges";
+			} else if(nodes != 1 && edges == 1) {
+				this.message = "Selected " + nodes + " nodes and 1 edge";
+			} else {
+				this.message = "Selected " + nodes + " nodes and " + edges + " edges";
+			}
+		}
+		else {
+			this.message = message;
+		}
 	}
 
-	public static SearchResults syntaxError(final String errorMessage) {
-		return new SearchResults(Status.ERROR_SYNTAX, errorMessage, null, null);
+	public static SearchResults syntaxError() {
+		return new SearchResults(Status.ERROR_SYNTAX, "Cannot execute search query", null, null);
+	}
+
+	public static SearchResults syntaxError(final String message) {
+		return new SearchResults(Status.ERROR_SYNTAX, message, null, null);
 	}
 
 	public static SearchResults fatalError() {
-		return new SearchResults(Status.ERROR_FATAL, null, null, null);
+		return new SearchResults(Status.ERROR_FATAL, "Query execution error", null, null);
 	}
 
-	public static SearchResults fatalError(final String errorMessage) {
-		return new SearchResults(Status.ERROR_FATAL, errorMessage, null, null);
+	public static SearchResults fatalError(final String message) {
+		return new SearchResults(Status.ERROR_FATAL, message, null, null);
 	}
 
 	public static SearchResults results(List<String> nodeHits, List<String> edgeHits) {
@@ -55,8 +69,8 @@ public class SearchResults {
 	 * Returns error message if any
 	 * @return Error message or null if no error
 	 */
-	public String getErrorMessage(){
-		return errorMessage;
+	public String getMessage(){
+		return message;
 	}
 
 	public int getNodeHitCount() {

--- a/search-impl/src/main/java/org/cytoscape/search/internal/SearchResults.java
+++ b/search-impl/src/main/java/org/cytoscape/search/internal/SearchResults.java
@@ -10,27 +10,37 @@ public class SearchResults {
 	}
 	
 	private final Status status;
+	private final String errorMessage;
 	private final List<String> nodeHits;
 	private final List<String> edgeHits;
 
 	
-	private SearchResults(Status status, List<String> nodeHits, List<String> edgeHits) {
+	private SearchResults(Status status, final String errorMessage, List<String> nodeHits, List<String> edgeHits) {
 		this.status = status;
-		this.nodeHits = nodeHits == null ? Collections.emptyList() : nodeHits;
-		this.edgeHits = edgeHits == null ? Collections.emptyList() : edgeHits;
+		this.errorMessage = errorMessage;
+		this.nodeHits = nodeHits == null ? Collections.<String>emptyList() : nodeHits;
+		this.edgeHits = edgeHits == null ? Collections.<String>emptyList() : edgeHits;
 	}
 	
 	
 	public static SearchResults syntaxError() {
-		return new SearchResults(Status.ERROR_SYNTAX, null, null);
+		return new SearchResults(Status.ERROR_SYNTAX, null, null, null);
 	}
-	
+
+	public static SearchResults syntaxError(final String errorMessage) {
+		return new SearchResults(Status.ERROR_SYNTAX, errorMessage, null, null);
+	}
+
 	public static SearchResults fatalError() {
-		return new SearchResults(Status.ERROR_FATAL, null, null);
+		return new SearchResults(Status.ERROR_FATAL, null, null, null);
 	}
-	
+
+	public static SearchResults fatalError(final String errorMessage) {
+		return new SearchResults(Status.ERROR_FATAL, errorMessage, null, null);
+	}
+
 	public static SearchResults results(List<String> nodeHits, List<String> edgeHits) {
-		return new SearchResults(Status.SUCCESS, nodeHits, edgeHits);
+		return new SearchResults(Status.SUCCESS, null, nodeHits, edgeHits);
 	}
 	
 	public boolean isError() {
@@ -41,6 +51,14 @@ public class SearchResults {
 		return status;
 	}
 	
+	/**
+	 * Returns error message if any
+	 * @return Error message or null if no error
+	 */
+	public String getErrorMessage(){
+		return errorMessage;
+	}
+
 	public int getNodeHitCount() {
 		return nodeHits.size();
 	}

--- a/search-impl/src/main/java/org/cytoscape/search/internal/ui/EnhancedSearchPanel.java
+++ b/search-impl/src/main/java/org/cytoscape/search/internal/ui/EnhancedSearchPanel.java
@@ -117,6 +117,9 @@ public class EnhancedSearchPanel extends JPanel {
 
 	
 	private void showPopup(SearchResults results) {
+		if (results == null) {
+			return;
+		}
 		JLabel label = new JLabel();
 		
 		if(results.isError()) {

--- a/search-impl/src/main/java/org/cytoscape/search/internal/ui/EnhancedSearchPanel.java
+++ b/search-impl/src/main/java/org/cytoscape/search/internal/ui/EnhancedSearchPanel.java
@@ -121,7 +121,11 @@ public class EnhancedSearchPanel extends JPanel {
 		
 		if(results.getStatus() == Status.ERROR_SYNTAX) {
 			label.setForeground(Color.RED);
-			label.setText("   Cannot execute search query   ");
+			if (results.getErrorMessage() != null) {
+				label.setText("   " + results.getErrorMessage() + "   ");
+			} else {
+				label.setText("   Cannot execute search query   ");
+			}
 		} else if(results.getStatus() == Status.ERROR_FATAL) {
 			label.setForeground(Color.RED);
 			label.setText("   Query execution error   ");

--- a/search-impl/src/main/java/org/cytoscape/search/internal/ui/EnhancedSearchPanel.java
+++ b/search-impl/src/main/java/org/cytoscape/search/internal/ui/EnhancedSearchPanel.java
@@ -119,29 +119,10 @@ public class EnhancedSearchPanel extends JPanel {
 	private void showPopup(SearchResults results) {
 		JLabel label = new JLabel();
 		
-		if(results.getStatus() == Status.ERROR_SYNTAX) {
+		if(results.isError()) {
 			label.setForeground(Color.RED);
-			if (results.getErrorMessage() != null) {
-				label.setText("   " + results.getErrorMessage() + "   ");
-			} else {
-				label.setText("   Cannot execute search query   ");
-			}
-		} else if(results.getStatus() == Status.ERROR_FATAL) {
-			label.setForeground(Color.RED);
-			label.setText("   Query execution error   ");
-		} else {
-			int edges = results.getEdgeHitCount();
-			int nodes = results.getNodeHitCount();
-			if(nodes == 1 && edges == 1) {
-				label.setText("   Selected 1 node and 1 edge   ");
-			} else if(nodes == 1 && edges != 1) {
-				label.setText("   Selected 1 node and " + edges + " edges   ");
-			} else if(nodes != 1 && edges == 1) {
-				label.setText("   Selected " + nodes + " nodes and 1 edge   ");
-			} else {
-				label.setText("   Selected " + nodes + " nodes and " + edges + " edges   ");
-			}
 		}
+		label.setText("   " + results.getMessage() + "   ");
 		
 		LookAndFeelUtil.makeSmall(label);
 		JPopupMenu popup = new JPopupMenu();

--- a/search-impl/src/main/java/org/cytoscape/search/internal/util/CustomMultiFieldQueryParser.java
+++ b/search-impl/src/main/java/org/cytoscape/search/internal/util/CustomMultiFieldQueryParser.java
@@ -50,6 +50,8 @@ public class CustomMultiFieldQueryParser extends MultiFieldQueryParser {
 		super(Version.LUCENE_30,attrFields.getFields(), analyzer);
 		this.attrFields = attrFields;
 		setAllowLeadingWildcard(true);
+		// a workaround to avoid a TooManyClauses exception.
+		BooleanQuery.setMaxClauseCount(5120); // 5 * 1024
 	}
 
 	protected Query getFieldQuery(String field, String queryText) throws ParseException {
@@ -92,11 +94,6 @@ public class CustomMultiFieldQueryParser extends MultiFieldQueryParser {
 	}
 
 	protected Query getRangeQuery(String field, String part1, String part2, boolean inclusive) throws ParseException {
-		
-		// a workaround to avoid a TooManyClauses exception.
-		// Temporary until RangeFilter is implemented.
-		BooleanQuery.setMaxClauseCount(5120); // 5 * 1024		
-		
 		if (attrFields.getType(field) == Integer.class) {
 			try {
 				

--- a/search-impl/src/test/java/org/cytoscape/search/internal/SearchResultsTest.java
+++ b/search-impl/src/test/java/org/cytoscape/search/internal/SearchResultsTest.java
@@ -35,7 +35,7 @@ public class SearchResultsTest {
 		SearchResults sr = SearchResults.syntaxError();
 		assertEquals(sr.getStatus(), SearchResults.Status.ERROR_SYNTAX);
 		assertTrue(sr.isError());
-		assertNull(sr.getErrorMessage());
+		assertEquals("Cannot execute search query", sr.getMessage());
 		assertEquals(0, sr.getEdgeHitCount());
 		assertEquals(0, sr.getNodeHitCount());
 		assertEquals(0, sr.getNodeHits().size());
@@ -47,7 +47,7 @@ public class SearchResultsTest {
 		SearchResults sr = SearchResults.syntaxError("some error");
 		assertEquals(sr.getStatus(), SearchResults.Status.ERROR_SYNTAX);
 		assertTrue(sr.isError());
-		assertEquals("some error", sr.getErrorMessage());
+		assertEquals("some error", sr.getMessage());
 		assertEquals(0, sr.getEdgeHitCount());
 		assertEquals(0, sr.getNodeHitCount());
 		assertEquals(0, sr.getNodeHits().size());
@@ -59,7 +59,7 @@ public class SearchResultsTest {
 		SearchResults sr = SearchResults.fatalError();
 		assertEquals(sr.getStatus(), SearchResults.Status.ERROR_FATAL);
 		assertTrue(sr.isError());
-		assertNull(sr.getErrorMessage());
+		assertEquals("Query execution error", sr.getMessage());
 		assertEquals(0, sr.getEdgeHitCount());
 		assertEquals(0, sr.getNodeHitCount());
 		assertEquals(0, sr.getNodeHits().size());
@@ -71,7 +71,7 @@ public class SearchResultsTest {
 		SearchResults sr = SearchResults.fatalError("some error");
 		assertEquals(sr.getStatus(), SearchResults.Status.ERROR_FATAL);
 		assertTrue(sr.isError());
-		assertEquals("some error", sr.getErrorMessage());
+		assertEquals("some error", sr.getMessage());
 		assertEquals(0, sr.getEdgeHitCount());
 		assertEquals(0, sr.getNodeHitCount());
 		assertEquals(0, sr.getNodeHits().size());
@@ -83,7 +83,7 @@ public class SearchResultsTest {
 		SearchResults sr = SearchResults.results(null, null);
 		assertEquals(sr.getStatus(), SearchResults.Status.SUCCESS);
 		assertFalse(sr.isError());
-		assertNull(sr.getErrorMessage());
+		assertEquals("Selected 0 nodes and 0 edges", sr.getMessage());
 		assertEquals(0, sr.getEdgeHitCount());
 		assertEquals(0, sr.getNodeHitCount());
 		assertEquals(0, sr.getNodeHits().size());
@@ -91,7 +91,24 @@ public class SearchResultsTest {
 	}
 	
 	@Test
-	public void testResults() {
+	public void testResultsOneNodeOneEdge() {
+		ArrayList<String> nodes = new ArrayList<String>();
+		nodes.add("node1");
+		ArrayList<String> edges = new ArrayList<String>();
+		edges.add("edge1");
+		
+		SearchResults sr = SearchResults.results(nodes, edges);
+		assertEquals(sr.getStatus(), SearchResults.Status.SUCCESS);
+		assertFalse(sr.isError());
+		assertEquals("Selected 1 node and 1 edge", sr.getMessage());
+		assertEquals(1, sr.getEdgeHitCount());
+		assertEquals(1, sr.getNodeHitCount());
+		assertEquals(1, sr.getNodeHits().size());
+		assertEquals(1, sr.getEdgeHits().size());
+	}
+	
+	@Test
+	public void testResultsOneNodeTwoEdges() {
 		ArrayList<String> nodes = new ArrayList<String>();
 		nodes.add("node1");
 		ArrayList<String> edges = new ArrayList<String>();
@@ -101,12 +118,28 @@ public class SearchResultsTest {
 		SearchResults sr = SearchResults.results(nodes, edges);
 		assertEquals(sr.getStatus(), SearchResults.Status.SUCCESS);
 		assertFalse(sr.isError());
-		assertNull(sr.getErrorMessage());
+		assertEquals("Selected 1 node and 2 edges", sr.getMessage());
 		assertEquals(2, sr.getEdgeHitCount());
 		assertEquals(1, sr.getNodeHitCount());
 		assertEquals(1, sr.getNodeHits().size());
 		assertEquals(2, sr.getEdgeHits().size());
 	}
 	
+	@Test
+	public void testResultsTwoNodesOneEdge() {
+		ArrayList<String> nodes = new ArrayList<String>();
+		nodes.add("node1");
+		nodes.add("node2");
+		ArrayList<String> edges = new ArrayList<String>();
+		edges.add("edge1");
 
+		SearchResults sr = SearchResults.results(nodes, edges);
+		assertEquals(sr.getStatus(), SearchResults.Status.SUCCESS);
+		assertFalse(sr.isError());
+		assertEquals("Selected 2 nodes and 1 edge", sr.getMessage());
+		assertEquals(1, sr.getEdgeHitCount());
+		assertEquals(2, sr.getNodeHitCount());
+		assertEquals(2, sr.getNodeHits().size());
+		assertEquals(1, sr.getEdgeHits().size());
+	}
 }

--- a/search-impl/src/test/java/org/cytoscape/search/internal/SearchResultsTest.java
+++ b/search-impl/src/test/java/org/cytoscape/search/internal/SearchResultsTest.java
@@ -1,0 +1,112 @@
+package org.cytoscape.search.internal;
+
+/*
+ * #%L
+ * Cytoscape Layout API (layout-api)
+ * $Id:$
+ * $HeadURL:$
+ * %%
+ * Copyright (C) 2006 - 2019 The Cytoscape Consortium
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as 
+ * published by the Free Software Foundation, either version 2.1 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
+import java.util.ArrayList;
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+public class SearchResultsTest {
+	
+	@Test
+	public void testSyntaxErrorNoArgs() {
+		SearchResults sr = SearchResults.syntaxError();
+		assertEquals(sr.getStatus(), SearchResults.Status.ERROR_SYNTAX);
+		assertTrue(sr.isError());
+		assertNull(sr.getErrorMessage());
+		assertEquals(0, sr.getEdgeHitCount());
+		assertEquals(0, sr.getNodeHitCount());
+		assertEquals(0, sr.getNodeHits().size());
+		assertEquals(0, sr.getEdgeHits().size());
+	}
+	
+	@Test
+	public void testSyntaxErrorWithErrorMessage() {
+		SearchResults sr = SearchResults.syntaxError("some error");
+		assertEquals(sr.getStatus(), SearchResults.Status.ERROR_SYNTAX);
+		assertTrue(sr.isError());
+		assertEquals("some error", sr.getErrorMessage());
+		assertEquals(0, sr.getEdgeHitCount());
+		assertEquals(0, sr.getNodeHitCount());
+		assertEquals(0, sr.getNodeHits().size());
+		assertEquals(0, sr.getEdgeHits().size());
+	}
+	
+	@Test
+	public void testFatalErrorNoArgs() {
+		SearchResults sr = SearchResults.fatalError();
+		assertEquals(sr.getStatus(), SearchResults.Status.ERROR_FATAL);
+		assertTrue(sr.isError());
+		assertNull(sr.getErrorMessage());
+		assertEquals(0, sr.getEdgeHitCount());
+		assertEquals(0, sr.getNodeHitCount());
+		assertEquals(0, sr.getNodeHits().size());
+		assertEquals(0, sr.getEdgeHits().size());
+	}
+	
+	@Test
+	public void testFatalErrorWithErrorMessage() {
+		SearchResults sr = SearchResults.fatalError("some error");
+		assertEquals(sr.getStatus(), SearchResults.Status.ERROR_FATAL);
+		assertTrue(sr.isError());
+		assertEquals("some error", sr.getErrorMessage());
+		assertEquals(0, sr.getEdgeHitCount());
+		assertEquals(0, sr.getNodeHitCount());
+		assertEquals(0, sr.getNodeHits().size());
+		assertEquals(0, sr.getEdgeHits().size());
+	}
+	
+	@Test
+	public void testResultsNullArgs() {
+		SearchResults sr = SearchResults.results(null, null);
+		assertEquals(sr.getStatus(), SearchResults.Status.SUCCESS);
+		assertFalse(sr.isError());
+		assertNull(sr.getErrorMessage());
+		assertEquals(0, sr.getEdgeHitCount());
+		assertEquals(0, sr.getNodeHitCount());
+		assertEquals(0, sr.getNodeHits().size());
+		assertEquals(0, sr.getEdgeHits().size());
+	}
+	
+	@Test
+	public void testResults() {
+		ArrayList<String> nodes = new ArrayList<String>();
+		nodes.add("node1");
+		ArrayList<String> edges = new ArrayList<String>();
+		edges.add("edge1");
+		edges.add("edge2");
+		
+		SearchResults sr = SearchResults.results(nodes, edges);
+		assertEquals(sr.getStatus(), SearchResults.Status.SUCCESS);
+		assertFalse(sr.isError());
+		assertNull(sr.getErrorMessage());
+		assertEquals(2, sr.getEdgeHitCount());
+		assertEquals(1, sr.getNodeHitCount());
+		assertEquals(1, sr.getNodeHits().size());
+		assertEquals(2, sr.getEdgeHits().size());
+	}
+	
+
+}


### PR DESCRIPTION
Fixed https://cytoscape.atlassian.net/browse/CYTOSCAPE-12553 by increasing the max allowed terms from 1,024 to 5,120. 

If that value is exceeded the code detects that error and reports to the user the query is too long. In addition, added a max query size of 65k. 

Finally added some timing to the log messages and put the building of the index and the query under separate threads so if a user cancels the task during those operations the task will quit within a second or two.
