### PR TITLE
NPE occurs if we attempt to draw an edge and the node view has not be…

### DIFF
--- a/viewmodel-impl/impl/src/main/java/org/cytoscape/view/model/internal/network/CyNetworkViewImpl.java
+++ b/viewmodel-impl/impl/src/main/java/org/cytoscape/view/model/internal/network/CyNetworkViewImpl.java
@@ -196,6 +196,9 @@ public class CyNetworkViewImpl extends CyViewBase<CyNetwork> implements CyNetwor
 		}
 		CyNodeViewImpl sourceView = dataSuidToNode.getOrElse(edge.getSource().getSUID(), null);
 		CyNodeViewImpl targetView = dataSuidToNode.getOrElse(edge.getTarget().getSUID(), null);
+		if (sourceView == null || targetView == null) {
+			return null;
+		}
 		CyEdgeViewImpl view = new CyEdgeViewImpl(this, edge, sourceView.getSUID(), targetView.getSUID());
 		
 		synchronized (edgeLock) {


### PR DESCRIPTION
…en created yet.  This will prevent that NPE from taking out the rest of the edges in the payload which could draw successfully.