### PR TITLE
Feature/cytoscape 13050

### DIFF
--- a/core-task-impl/pom.xml
+++ b/core-task-impl/pom.xml
@@ -138,6 +138,13 @@
 			<groupId>org.cytoscape</groupId>
 			<artifactId>util-api</artifactId>
 		</dependency>
+		
+		<!-- Internal API -->
+		<dependency>
+			<groupId>org.cytoscape</groupId>
+			<artifactId>custom-graphics-internal</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 
 		<!-- 3rd party library -->
 		<dependency>

--- a/core-task-impl/src/main/java/org/cytoscape/task/internal/session/OpenSessionCommandTask.java
+++ b/core-task-impl/src/main/java/org/cytoscape/task/internal/session/OpenSessionCommandTask.java
@@ -9,6 +9,7 @@ import java.nio.channels.Channels;
 import org.apache.commons.io.FilenameUtils;
 import org.cytoscape.application.CyApplicationManager;
 import org.cytoscape.application.CyUserLog;
+import org.cytoscape.cg.event.CustomGraphicsReadyToBeLoadedEvent;
 import org.cytoscape.event.CyEventHelper;
 import org.cytoscape.io.read.CySessionReaderManager;
 import org.cytoscape.io.util.RecentlyOpenedTracker;
@@ -147,8 +148,13 @@ public class OpenSessionCommandTask extends AbstractOpenSessionTask {
 				tm.setProgress(0.2);
 				
 				// Now we can read the new session
-				if (!cancelled)
+				if (!cancelled) {
 					reader.run(tm);
+					
+					// The CustomGraphicsManager needs to load images before the session is restored.
+					tm.setProgress(0.7);
+					eventHelper.fireEvent(new CustomGraphicsReadyToBeLoadedEvent(this, reader.getSession()));
+				}
 				
 				tm.setProgress(0.8);
 			} catch (Exception e) {

--- a/core-task-impl/src/main/java/org/cytoscape/task/internal/session/OpenSessionTask.java
+++ b/core-task-impl/src/main/java/org/cytoscape/task/internal/session/OpenSessionTask.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.cytoscape.cg.event.CustomGraphicsReadyToBeLoadedEvent;
 import org.cytoscape.event.CyEventHelper;
 import org.cytoscape.io.read.CySessionReaderManager;
 import org.cytoscape.io.util.RecentlyOpenedTracker;
@@ -113,9 +114,7 @@ public class OpenSessionTask extends AbstractOpenSessionTask {
 					if (file == null)
 						throw new NullPointerException("No file specified.");
 					
-					reader = serviceRegistrar.getService(CySessionReaderManager.class)
-							.getReader(file.toURI(), file.getName());
-					
+					reader = serviceRegistrar.getService(CySessionReaderManager.class).getReader(file.toURI(), file.getName());
 					if (reader == null)
 						throw new NullPointerException("Failed to find appropriate reader for file: " + file);
 					
@@ -128,8 +127,13 @@ public class OpenSessionTask extends AbstractOpenSessionTask {
 					tm.setProgress(0.2);
 					
 					// Now we can read the new session
-					if (!cancelled)
+					if (!cancelled) {
 						reader.run(tm);
+						
+						// The CustomGraphicsManager needs to load images before the session is restored.
+						tm.setProgress(0.7);
+						eventHelper.fireEvent(new CustomGraphicsReadyToBeLoadedEvent(this, reader.getSession()));
+					}
 					
 					tm.setProgress(0.8);
 				} catch (Exception e) {

--- a/custom-graphics-internal/src/main/java/org/cytoscape/cg/event/CustomGraphicsReadyToBeLoadedEvent.java
+++ b/custom-graphics-internal/src/main/java/org/cytoscape/cg/event/CustomGraphicsReadyToBeLoadedEvent.java
@@ -1,0 +1,21 @@
+package org.cytoscape.cg.event;
+
+import org.cytoscape.event.AbstractCyEvent;
+import org.cytoscape.session.CySession;
+
+/**
+ * Local event to handle graphics library update
+ */
+public final class CustomGraphicsReadyToBeLoadedEvent extends AbstractCyEvent<Object> {
+
+	private final CySession session;
+	
+	public CustomGraphicsReadyToBeLoadedEvent(Object source, CySession session) {
+		super(source, CustomGraphicsReadyToBeLoadedListener.class);
+		this.session = session;
+	}
+	
+	public CySession getLoadedSession() {
+		return session;
+	}
+}

--- a/custom-graphics-internal/src/main/java/org/cytoscape/cg/event/CustomGraphicsReadyToBeLoadedListener.java
+++ b/custom-graphics-internal/src/main/java/org/cytoscape/cg/event/CustomGraphicsReadyToBeLoadedListener.java
@@ -1,0 +1,8 @@
+package org.cytoscape.cg.event;
+
+import org.cytoscape.event.CyListener;
+
+public interface CustomGraphicsReadyToBeLoadedListener extends CyListener {
+	
+	void handleEvent(CustomGraphicsReadyToBeLoadedEvent e);
+}

--- a/custom-graphics-internal/src/main/java/org/cytoscape/cg/internal/model/CustomGraphicsManagerImpl.java
+++ b/custom-graphics-internal/src/main/java/org/cytoscape/cg/internal/model/CustomGraphicsManagerImpl.java
@@ -18,6 +18,8 @@ import org.apache.commons.io.FileUtils;
 import org.cytoscape.application.CyUserLog;
 import org.cytoscape.application.events.CyStartEvent;
 import org.cytoscape.application.events.CyStartListener;
+import org.cytoscape.cg.event.CustomGraphicsReadyToBeLoadedEvent;
+import org.cytoscape.cg.event.CustomGraphicsReadyToBeLoadedListener;
 import org.cytoscape.cg.internal.image.MissingImageCustomGraphics;
 import org.cytoscape.cg.internal.task.RestoreImagesTask;
 import org.cytoscape.cg.internal.task.SaveGraphicsToSessionTaskFactory;
@@ -34,8 +36,6 @@ import org.cytoscape.session.events.SessionAboutToBeLoadedEvent;
 import org.cytoscape.session.events.SessionAboutToBeLoadedListener;
 import org.cytoscape.session.events.SessionAboutToBeSavedEvent;
 import org.cytoscape.session.events.SessionAboutToBeSavedListener;
-import org.cytoscape.session.events.SessionLoadedEvent;
-import org.cytoscape.session.events.SessionLoadedListener;
 import org.cytoscape.view.model.CyNetworkView;
 import org.cytoscape.view.model.VisualLexicon;
 import org.cytoscape.view.model.VisualProperty;
@@ -57,7 +57,7 @@ import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("rawtypes")
 public final class CustomGraphicsManagerImpl implements CustomGraphicsManager, CyStartListener,
-		SessionAboutToBeSavedListener, SessionAboutToBeLoadedListener, SessionLoadedListener {
+		SessionAboutToBeSavedListener, SessionAboutToBeLoadedListener, CustomGraphicsReadyToBeLoadedListener {
 
 	private static final Logger logger = LoggerFactory.getLogger(CyUserLog.NAME);
 
@@ -346,7 +346,7 @@ public final class CustomGraphicsManagerImpl implements CustomGraphicsManager, C
 	}
 
 	@Override
-	public void handleEvent(SessionLoadedEvent e) {
+	public void handleEvent(CustomGraphicsReadyToBeLoadedEvent e) {
 		// Add new images
 		var sess = e.getLoadedSession();
 

--- a/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/impl/canvas/AnnotationCanvas.java
+++ b/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/impl/canvas/AnnotationCanvas.java
@@ -68,12 +68,15 @@ public class AnnotationCanvas<GP extends GraphicsProvider> extends DingCanvas<GP
 		if(g == null)
 			return;
 		
+		var annotations = re.getCyAnnotator().getAnnotations(canvasID, false);
+		if(annotations == null || annotations.isEmpty())
+			return;
+		
 		var transform = graphicsProvider.getTransform();
 		g.transform(transform.getPaintAffineTransform());
 		
 		Rectangle2D visibleArea = transform.getNetworkVisibleAreaNodeCoords();
 		
-		var annotations = re.getCyAnnotator().getAnnotations(canvasID, false);
 		var dpm = pm.toDiscrete(annotations.size());
 		
 		for(DingAnnotation a : annotations) {

--- a/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/impl/cyannotator/CyAnnotator.java
+++ b/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/impl/cyannotator/CyAnnotator.java
@@ -105,7 +105,6 @@ public class CyAnnotator implements SessionAboutToBeSavedListener, CustomGraphic
 	
 	@Override
 	public void handleEvent(CustomGraphicsLibraryUpdatedEvent evt) {
-		System.out.println("CyAnnotator.handleEvent(CustomGraphicsLibraryUpdatedEvent)");
 		var iterator = new TaskIterator(new ReloadImagesTask(this));
 		registrar.getService(TaskManager.class).execute(iterator);
 	}
@@ -187,7 +186,6 @@ public class CyAnnotator implements SessionAboutToBeSavedListener, CustomGraphic
 	public void loadAnnotations(List<String> annotations) {
 		loading = true;
 		
-		System.out.println("CyAnnotator.loadAnnotations()");
 		try {
 			var arrowList = new ArrayList<Map<String, String>>(); // Keep a list of arrows
 			var groupMap = new HashMap<GroupAnnotation, String>(); // Keep a map of groups and uuids

--- a/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/impl/cyannotator/CyAnnotator.java
+++ b/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/impl/cyannotator/CyAnnotator.java
@@ -105,6 +105,7 @@ public class CyAnnotator implements SessionAboutToBeSavedListener, CustomGraphic
 	
 	@Override
 	public void handleEvent(CustomGraphicsLibraryUpdatedEvent evt) {
+		System.out.println("CyAnnotator.handleEvent(CustomGraphicsLibraryUpdatedEvent)");
 		var iterator = new TaskIterator(new ReloadImagesTask(this));
 		registrar.getService(TaskManager.class).execute(iterator);
 	}
@@ -186,6 +187,7 @@ public class CyAnnotator implements SessionAboutToBeSavedListener, CustomGraphic
 	public void loadAnnotations(List<String> annotations) {
 		loading = true;
 		
+		System.out.println("CyAnnotator.loadAnnotations()");
 		try {
 			var arrowList = new ArrayList<Map<String, String>>(); // Keep a list of arrows
 			var groupMap = new HashMap<GroupAnnotation, String>(); // Keep a map of groups and uuids
@@ -313,8 +315,9 @@ public class CyAnnotator implements SessionAboutToBeSavedListener, CustomGraphic
 		var oldValue = new HashSet<>(annotationSet);
 		
 		for (var a : annotations) {
-			if (a instanceof DingAnnotation)
-				annotationSet.add((DingAnnotation) a);
+			if (a instanceof DingAnnotation da) {
+				annotationSet.add(da);
+			}
 		}
 		
 		getAnnotationTree().resetZOrder();
@@ -534,15 +537,7 @@ public class CyAnnotator implements SessionAboutToBeSavedListener, CustomGraphic
 			annotation = (DingAnnotation) a;
 
 			uuidMap.put(annotation.getUUID().toString(), annotation);
-			CanvasID canvas;
-
-			if (annotation.getCanvas() != null) {
-//				annotation.getCanvas().add(annotation);
-				canvas = annotation.getCanvas();
-			} else {
-				canvas = CanvasID.FOREGROUND;
-//				foreGroundCanvas.add(annotation);
-			}
+			var canvas = annotation.getCanvas() == null ? CanvasID.FOREGROUND : annotation.getCanvas();
 
 			if (argMap.containsKey(Annotation.Z)) {
 				int zOrder = Integer.parseInt(argMap.get(Annotation.Z));

--- a/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/impl/cyannotator/annotations/ImageAnnotationImpl.java
+++ b/ding-impl/ding-presentation-impl/src/main/java/org/cytoscape/ding/impl/cyannotator/annotations/ImageAnnotationImpl.java
@@ -220,22 +220,23 @@ public class ImageAnnotationImpl extends ShapeAnnotationImpl implements ImageAnn
 			// Get the image from the image pool
 			try {
 				url = new URL(argMap.get(URL));
-        reloadImage();
-				
-        if (name == null)
-          name = getDefaultName();
+				reloadImage();
 
-        double aspectRatio = (double)image.getHeight() / (double)image.getWidth();
-        // If the user didn't specify the WIDTH and HEIGHT, it will be set to 100X100.  We want to
-        // scale that to the appropriate aspect ratio
-        if (argMap.containsKey(ShapeAnnotation.WIDTH) && argMap.containsKey(ShapeAnnotation.HEIGHT))
-          return;
+				if (name == null)
+					name = getDefaultName();
 
-        // If the user specified the width, adjust the height
-        if (argMap.containsKey(ShapeAnnotation.WIDTH))
-          height = width*aspectRatio;
-        else
-          width = height/aspectRatio;
+				double aspectRatio = (double) image.getHeight() / (double) image.getWidth();
+				// If the user didn't specify the WIDTH and HEIGHT, it will be set to 100X100.
+				// We want to
+				// scale that to the appropriate aspect ratio
+				if (argMap.containsKey(ShapeAnnotation.WIDTH) && argMap.containsKey(ShapeAnnotation.HEIGHT))
+					return;
+
+				// If the user specified the width, adjust the height
+				if (argMap.containsKey(ShapeAnnotation.WIDTH))
+					height = width * aspectRatio;
+				else
+					width = height / aspectRatio;
 
 			} catch (Exception e) {
 				logger.warn("Unable to restore image '" + argMap.get(URL) + "'", e);
@@ -319,22 +320,22 @@ public class ImageAnnotationImpl extends ShapeAnnotationImpl implements ImageAnn
 			if (cg != null) {
 				if (!isSVG())
 					image = ImageUtil.toBufferedImage(cg.getRenderedImage());
-        modifiedImage = null;
-				
+				modifiedImage = null;
+
 				customGraphicsManager.addCustomGraphics(cg, url);
 				customGraphicsManager.setUsedInCurrentSession(cg, true);
 			} else {
-        try {
-          // We don't already have the image -- fetch it
-          image = ImageIO.read(url);
-          cg = new BitmapCustomGraphics(customGraphicsManager.getNextAvailableID(), url.toString(), image);
-          customGraphicsManager.addCustomGraphics(cg, url);
-          customGraphicsManager.setUsedInCurrentSession(cg, true);
-          modifiedImage = null;
-        } catch (Exception e) {
-          logger.error("Unable to read image from "+ url.toString() + ": "+e.getMessage());
-          throw e;
-        }
+				try {
+					// We don't already have the image -- fetch it
+					image = ImageIO.read(url);
+					cg = new BitmapCustomGraphics(customGraphicsManager.getNextAvailableID(), url.toString(), image);
+					customGraphicsManager.addCustomGraphics(cg, url);
+					customGraphicsManager.setUsedInCurrentSession(cg, true);
+					modifiedImage = null;
+				} catch (Exception e) {
+					logger.error("Unable to read image from " + url.toString() + ": " + e.getMessage());
+					throw e;
+				}
 			}
 		} catch (Exception e) {
 			logger.warn("Unable to restore image '" + url + "'", e);
@@ -383,7 +384,7 @@ public class ImageAnnotationImpl extends ShapeAnnotationImpl implements ImageAnn
 		var oldValue = this.url;
 		this.url = url;
 		reloadImage();
-    getModifiedImage();
+		getModifiedImage();
 		update();
 		firePropertyChange("imageURL", oldValue, url);
 	}


### PR DESCRIPTION
Recent changes to custom graphics removed the loading of images from the CytoscapeConfiguration folder when Cytoscape starts up. Its my understanding that images are now only loaded from the session file. 

The problem is that images are loaded by the CustomGraphicsManager in response to a SessionLoadedEvent, which fires when the session is done loading, but there are things in the session that need the images during session load, like image annotations.

This pull request adds a new event which is fired after the session file is read into memory, but before the session is restored by the SessionManager. This makes it so the custom graphics are restored before the session is restored, so the images are available to everything in the session. The new event is in the `custom-graphics-internal` bundle so its not API.

Note: The changes to ImageAnnotationImpl are just reformating.