### PR TITLE
Fix wrong attractive force in Edge-weighted Force directed layout

### DIFF
--- a/layout-cytoscape-impl/src/main/java/csapps/layout/algorithms/bioLayout/BioLayoutFRAlgorithmTask.java
+++ b/layout-cytoscape-impl/src/main/java/csapps/layout/algorithms/bioLayout/BioLayoutFRAlgorithmTask.java
@@ -707,6 +707,6 @@ public class BioLayoutFRAlgorithmTask extends BioLayoutAlgorithmTask {
 	 */
 /// fa(z) := begin return z*z/k end;
 	private double forceA(double k, double distance, double weight) {
-		return ((distance / k) * weight);
+		return ((distance * distance / k) * weight);
 	}
 }


### PR DESCRIPTION
Fruchterman-Reingold attractive force is d^2/k not d/k. see original paper: https://doi.org/10.1002/spe.4380211102