### PR TITLE
fixed notification bell for app store core up…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: Continuous Integration
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: 'maven'
+
+    - name: Build platform toolchain and run app-impl tests
+      run: xvfb-run bash platform-unit-test.sh

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+--settings=.mvn/settings.xml

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,0 +1,10 @@
+<settings>
+  <mirrors>
+    <mirror>
+      <id>maven-default-http-blocker</id>
+      <mirrorOf>dummy</mirrorOf>
+      <name>Dummy mirror</name>
+      <url>http://0.0.0.0/</url>
+    </mirror>
+  </mirrors>
+</settings>

--- a/app-impl/src/main/java/org/cytoscape/app/internal/action/UpdateNotificationAction.java
+++ b/app-impl/src/main/java/org/cytoscape/app/internal/action/UpdateNotificationAction.java
@@ -36,6 +36,8 @@ import org.cytoscape.util.swing.IconManager;
 import org.cytoscape.util.swing.TextIcon;
 import org.cytoscape.work.TaskIterator;
 import org.cytoscape.work.TaskManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 /*
  * #%L
  * Cytoscape App Impl (app-impl)
@@ -62,6 +64,8 @@ import org.cytoscape.work.TaskManager;
 
 @SuppressWarnings("serial")
 public class UpdateNotificationAction extends AbstractCyAction {
+	private static final Logger sysLogger = LoggerFactory.getLogger(UpdateNotificationAction.class);
+
 	final CyServiceRegistrar serviceRegistrar;
 	private final BadgeIcon icon;
 
@@ -94,7 +98,13 @@ public class UpdateNotificationAction extends AbstractCyAction {
 		setToolbarGravity(Float.MAX_VALUE);
 
 		appManager.addAppListener(evt -> updateEnableState(true));
-		updateManager.addUpdatesChangedListener(evt -> updateEnableState(false));
+		updateManager.addUpdatesChangedListener(evt -> {
+			sysLogger.info("[bell-diag] UpdateNotificationAction received UpdatesChangedEvent");
+			updateEnableState(false);
+		});
+		// [bell-diag] If this line is timestamped AFTER UpdateManager's fireUpdatesChangedEvent line,
+		// the startup update event was fired before the bell registered its listener (startup race).
+		sysLogger.info("[bell-diag] UpdateNotificationAction constructed and UpdatesChangedListener registered");
 	}
 
 	@Override
@@ -495,6 +505,10 @@ public class UpdateNotificationAction extends AbstractCyAction {
 		putValue(LONG_DESCRIPTION, text);
 		icon.setCount(count);
 		setEnabled(count > 0); // this should force the UI to repaint because we disabled this action previously
+
+		// [bell-diag] This is the moment the bell badge is (re)painted. count>0 here == bell should light up.
+		sysLogger.info("[bell-diag] updateEnableState: count={}, setEnabled({}) on thread {}",
+				count, count > 0, Thread.currentThread().getName());
 	}
 
 	public void updateEnableState(boolean checkForUpdates) {

--- a/app-impl/src/main/java/org/cytoscape/app/internal/net/UpdateManager.java
+++ b/app-impl/src/main/java/org/cytoscape/app/internal/net/UpdateManager.java
@@ -117,7 +117,12 @@ public class UpdateManager implements AppsFinishedStartingListener {
 	
 	private void fireUpdatesChangedEvent() {
 		UpdatesChangedEvent evt = new UpdatesChangedEvent(this);
-		
+
+		// [bell-diag] If listenerCount is 0 here, the bell action had not yet registered its listener
+		// when the update set was computed (startup race) -> badge never receives the count.
+		sysLogger.info("[bell-diag] fireUpdatesChangedEvent: notifying {} listener(s), updates.size()={}",
+				updatesChangedListeners.size(), updates.size());
+
 		for (UpdatesChangedListener listener : updatesChangedListeners)
 			listener.updatesChanged(evt);
 	}
@@ -128,25 +133,54 @@ public class UpdateManager implements AppsFinishedStartingListener {
 
 	@Override
 	public void handleEvent(AppsFinishedStartingEvent evt) {
+		sysLogger.info("[bell-diag] handleEvent(AppsFinishedStartingEvent) invoked on thread {}", Thread.currentThread().getName());
 		final ExecutorService service = Executors.newSingleThreadExecutor();
 		service.submit(() -> {
-			for (DownloadSite downloadSite : downloadSitesManager.getDownloadSites()) {
-				appManager.getWebQuerier().setCurrentSiteName(downloadSite.getSiteName());
-				appManager.getWebQuerier().setCurrentAppStoreUrl(downloadSite.getSiteUrl());
-				appManager.getWebQuerier().getAllApps();
+			// [bell-diag] Wrap the whole body: previously any exception here was captured in the
+			// discarded Future and silently swallowed, leaving the update bell dark with no log trace.
+			try {
+				final int siteCount = downloadSitesManager.getDownloadSites().size();
+				final int installedCount = appManager.getInstalledApps().size();
+				sysLogger.info("[bell-diag] startup update check START: {} download site(s), {} installed app(s)", siteCount, installedCount);
+				userLogger.info("[bell-diag] App update startup check started (" + siteCount + " site(s), " + installedCount + " installed app(s))");
+
+				// [bell-diag][FIX] Always fetch the DEFAULT Cytoscape App Store catalog first.
+				// The loop below only covers custom download sites (DownloadSitesManager), which
+				// does NOT include the default store; without this fetch, checkForUpdates() compares
+				// installed apps against an empty appsByUrl cache and finds nothing -> bell stays dark.
+				appManager.getWebQuerier().setCurrentAppStoreUrl(WebQuerier.DEFAULT_APP_STORE_URL);
+				final int defaultStoreCount = appManager.getWebQuerier().getAllApps().size();
+				sysLogger.info("[bell-diag][FIX] default store getAllApps ({}) returned {} app(s)",
+						WebQuerier.DEFAULT_APP_STORE_URL, defaultStoreCount);
+
+				for (DownloadSite downloadSite : downloadSitesManager.getDownloadSites()) {
+					appManager.getWebQuerier().setCurrentSiteName(downloadSite.getSiteName());
+					appManager.getWebQuerier().setCurrentAppStoreUrl(downloadSite.getSiteUrl());
+					final int appCount = appManager.getWebQuerier().getAllApps().size();
+					sysLogger.info("[bell-diag] getAllApps for site '{}' ({}) returned {} app(s)",
+							downloadSite.getSiteName(), downloadSite.getSiteUrl(), appCount);
+				}
+
+				checkForUpdates(appManager.getInstalledApps());
+
+				// [bell-diag] Log the count UNCONDITIONALLY (the original only logged when > 0, so the
+				// "found zero" case was invisible).
+				sysLogger.info("[bell-diag] startup update check FINISHED: updates.size()={}", updates.size());
+				userLogger.info("[bell-diag] App update startup check finished: " + updates.size() + " update(s) found");
+
+				for (Update update : updates) {
+					userLogger.info(
+							"Update for " + update +
+							" available (latest version: " + update.getUpdateVersion() + ", " + update.getApp().getVersion() + " installed)"
+					);
+				}
+
+				if (updates.size() > 0)
+					userLogger.info(updates.size() + " " + (updates.size() == 1 ? "update" : "updates") + " available");
+			} catch (Throwable t) {
+				sysLogger.error("[bell-diag] startup update check FAILED with an exception", t);
+				userLogger.error("[bell-diag] App update startup check failed: " + t);
 			}
-			
-			checkForUpdates(appManager.getInstalledApps());
-			
-			for (Update update : updates) {
-				userLogger.info(
-						"Update for " + update + 
-						" available (latest version: " + update.getUpdateVersion() + ", " + update.getApp().getVersion() + " installed)"
-				);
-			}
-			
-			if (updates.size() > 0)
-				userLogger.info(updates.size() + " " + (updates.size() == 1 ? "update" : "updates") + " available");
 		});
 	}
 }

--- a/app-impl/src/test/java/org/cytoscape/app/internal/net/UpdateManagerTest.java
+++ b/app-impl/src/test/java/org/cytoscape/app/internal/net/UpdateManagerTest.java
@@ -1,0 +1,177 @@
+package org.cytoscape.app.internal.net;
+
+import static org.cytoscape.property.CyProperty.SavePolicy.DO_NOT_SAVE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.cytoscape.app.internal.manager.App;
+import org.cytoscape.app.internal.manager.AppManager;
+import org.cytoscape.app.internal.ui.downloadsites.DownloadSitesManager;
+import org.cytoscape.property.CyProperty;
+import org.cytoscape.property.SimpleCyProperty;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+
+/*
+ * #%L
+ * Cytoscape App Impl (app-impl)
+ * $Id:$
+ * $HeadURL:$
+ * %%
+ * Copyright (C) 2008 - 2026 The Cytoscape Consortium
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
+/**
+ * Regression coverage for the startup update check that drives the App Updates
+ * notification "bell".
+ *
+ * <p>The bug: {@link UpdateManager#handleEvent} only fetched app catalogs for the
+ * custom download sites in {@link DownloadSitesManager}, never the default Cytoscape
+ * App Store. {@link WebQuerier#checkForUpdates} only reads the already-cached catalog,
+ * so with no custom sites it compared against an empty catalog and found nothing,
+ * leaving the bell dark. The fix fetches the default App Store catalog before checking.
+ */
+public class UpdateManagerTest {
+
+	private AppManager appManager;
+	private WebQuerier webQuerier;
+	private DownloadSitesManager downloadSitesManager; // real, with zero custom sites
+	private UpdateManager updateManager;
+
+	@Before
+	public void setUp() {
+		appManager = mock(AppManager.class);
+		webQuerier = mock(WebQuerier.class);
+
+		// A real manager backed by empty properties => getDownloadSites() is empty,
+		// exactly the common case (no user-added download sites) that used to break the bell.
+		Properties properties = new Properties();
+		CyProperty<Properties> cyProperty = new SimpleCyProperty<Properties>(
+				"TestProperties", properties, properties.getClass(), DO_NOT_SAVE);
+		downloadSitesManager = new DownloadSitesManager(cyProperty);
+
+		// Build mock-backed values BEFORE the outer when(...) calls: the helpers use their own
+		// when(...) stubbing internally, and nesting that inside when(x).thenReturn(...) trips
+		// Mockito's UnfinishedStubbingException.
+		Set<App> installed = installedApps();
+
+		when(appManager.getWebQuerier()).thenReturn(webQuerier);
+		when(appManager.getInstalledApps()).thenReturn(installed);
+		// getAllApps() is called for its .size(); return non-null so the fetch step is a no-op catalog.
+		when(webQuerier.getAllApps()).thenReturn(Collections.<WebApp>emptySet());
+
+		updateManager = new UpdateManager(appManager, downloadSitesManager);
+	}
+
+	/** Precondition sanity: the scenario really has no custom download sites. */
+	@Test
+	public void testNoCustomDownloadSites() {
+		assertEquals(0, downloadSitesManager.getDownloadSites().size());
+	}
+
+	/**
+	 * The fix: even with zero custom download sites, the startup check must fetch the
+	 * DEFAULT App Store catalog. Before the fix this call never happened, so no updates
+	 * were ever found at startup.
+	 */
+	@Test
+	public void testHandleEventFetchesDefaultAppStore() throws Exception {
+		Set<Update> found = oneUpdate();
+		when(webQuerier.checkForUpdates(any(), any())).thenReturn(found);
+
+		CountDownLatch done = awaitCheckComplete();
+		updateManager.handleEvent(null); // handleEvent does not use the event object
+		assertTrue("startup update check did not complete in time", done.await(5, TimeUnit.SECONDS));
+
+		verify(webQuerier).setCurrentAppStoreUrl(WebQuerier.DEFAULT_APP_STORE_URL);
+		verify(webQuerier, atLeastOnce()).getAllApps();
+	}
+
+	/** The default store must be fetched BEFORE checkForUpdates reads the cache. */
+	@Test
+	public void testDefaultStoreFetchedBeforeCheckingForUpdates() throws Exception {
+		Set<Update> found = oneUpdate();
+		when(webQuerier.checkForUpdates(any(), any())).thenReturn(found);
+
+		CountDownLatch done = awaitCheckComplete();
+		updateManager.handleEvent(null);
+		assertTrue("startup update check did not complete in time", done.await(5, TimeUnit.SECONDS));
+
+		InOrder inOrder = inOrder(webQuerier);
+		inOrder.verify(webQuerier).setCurrentAppStoreUrl(WebQuerier.DEFAULT_APP_STORE_URL);
+		inOrder.verify(webQuerier).getAllApps();
+		inOrder.verify(webQuerier).checkForUpdates(any(), any());
+	}
+
+	/** End result: an available update surfaces in the count the bell reads. */
+	@Test
+	public void testUpdateCountReflectsFoundUpdate() throws Exception {
+		Set<Update> found = oneUpdate();
+		when(webQuerier.checkForUpdates(any(), any())).thenReturn(found);
+
+		CountDownLatch done = awaitCheckComplete();
+		updateManager.handleEvent(null);
+		assertTrue("startup update check did not complete in time", done.await(5, TimeUnit.SECONDS));
+
+		assertEquals(1, updateManager.getUpdateCount());
+	}
+
+	// ---- helpers ----
+
+	/** Registers a listener that trips a latch when the update set has been (re)computed. */
+	private CountDownLatch awaitCheckComplete() {
+		CountDownLatch latch = new CountDownLatch(1);
+		updateManager.addUpdatesChangedListener(evt -> latch.countDown());
+		return latch;
+	}
+
+	private Set<App> installedApps() {
+		App app = mock(App.class);
+		when(app.getVersion()).thenReturn("3.7.0");
+		when(app.getAppName()).thenReturn("CyNDEx-2");
+		Set<App> apps = new HashSet<>();
+		apps.add(app);
+		return apps;
+	}
+
+	private Set<Update> oneUpdate() {
+		App app = mock(App.class);
+		when(app.getVersion()).thenReturn("3.7.0");
+		when(app.getAppName()).thenReturn("CyNDEx-2");
+		Update update = mock(Update.class);
+		when(update.getApp()).thenReturn(app);
+		when(update.getUpdateVersion()).thenReturn("3.7.3");
+		Set<Update> updates = new HashSet<>();
+		updates.add(update);
+		return updates;
+	}
+}

--- a/platform-unit-test.sh
+++ b/platform-unit-test.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Build the Cytoscape platform toolchain (parent + api) from source into the local Maven repo, then
+# run the app-impl unit tests. Usable standalone by developers and invoked by CI (.github/workflows/ci.yml).
+#
+# The parent/api artifacts for this version are not published to any public Maven repo, so they are
+# built from source (cytoscape-parent, cytoscape-api) at the tag matching this repo's api version.
+#
+# Env overrides:
+#   CY_REF      git ref for the parent/api clones (default: derived from pom.xml)
+#   LOCAL_REPO  Maven local repository (default: ~/.m2/repository; set to a mktemp dir for a clean run)
+set -euo pipefail
+
+REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+cd "$REPO_ROOT"   # in-tree mvn (the app-impl test) then picks up .mvn/maven.config automatically
+SETTINGS="$REPO_ROOT/.mvn/settings.xml"
+LOCAL_REPO="${LOCAL_REPO:-$HOME/.m2/repository}"   # override (e.g. a mktemp dir) to force a clean bootstrap
+
+# Toolchain ref from the impl pom (XML parse; Maven can't evaluate the pom until its parent is installed below).
+if [ -z "${CY_REF:-}" ]; then
+  VER="$(python3 -c "import xml.etree.ElementTree as ET; ns={'m':'http://maven.apache.org/POM/4.0.0'}; \
+print(ET.parse('pom.xml').getroot().find('m:properties/m:cytoscape.api.version', ns).text)")"
+  case "$VER" in *-SNAPSHOT) CY_REF=develop ;; *) CY_REF="$VER" ;; esac
+fi
+echo "Cytoscape toolchain ref: $CY_REF ; local repo: $LOCAL_REPO"
+
+# Build parent + api into $LOCAL_REPO when absent (skipped once present). These use a pom OUTSIDE the
+# impl repo (-f), so Maven derives the .mvn base dir from that pom's location, not cwd — .mvn/maven.config
+# does NOT apply to them. Pass the settings explicitly with -s.
+if [ ! -f "$LOCAL_REPO/org/cytoscape/api-bundle/$CY_REF/api-bundle-$CY_REF.jar" ]; then
+  work="$(mktemp -d)"
+  git clone --depth 1 --branch "$CY_REF" https://github.com/cytoscape/cytoscape-parent.git "$work/parent"
+  mvn -B -s "$SETTINGS" -Dmaven.repo.local="$LOCAL_REPO" -f "$work/parent/pom.xml" install
+  git clone --depth 1 --branch "$CY_REF" https://github.com/cytoscape/cytoscape-api.git "$work/api"
+  mvn -B -s "$SETTINGS" -Dmaven.repo.local="$LOCAL_REPO" -f "$work/api/pom.xml" -pl event-api install -DskipTests  # event-api first
+  mvn -B -s "$SETTINGS" -Dmaven.repo.local="$LOCAL_REPO" -f "$work/api/pom.xml" install -DskipTests                # then full api reactor
+fi
+
+# Run the app-impl tests (in-tree: .mvn/maven.config applies the settings; -s added for parity).
+mvn -B -s "$SETTINGS" -Dmaven.repo.local="$LOCAL_REPO" -pl app-impl test


### PR DESCRIPTION
The notification bell wasn't highlighted when app store updates were detected for core apps.

I paired up with Claude to investigate and the root cause was found to be a transient race on cached data:

> The notification bell never lit because the startup update check never fetched the default App Store catalog.
>  
>  Concretely, in app-impl:
>
 > 1. UpdateManager.handleEvent (runs on AppsFinishedStartingEvent) fetched app catalogs only for custom download sites in DownloadSitesManager. That manager holds user-added sites only — the default store (apps.cytoscape.org)
  isn't in it. With no custom sites, the fetch loop ran zero times.
>  2. WebQuerier.checkForUpdates doesn't fetch anything — it only reads the already-cached appsByUrl map. Since the default store was never fetched, that cache was empty, so it found 0 updates → setEnabled(false) → bell dark.
 > 3. This is why apps list updates could report "1 update" while the bell stayed dark: that command ran later, after the App Manager/CyBrowser panel had already called getAllApps() on the default store and populated the cache.
  Same cache, but only the panel's path had filled it.
>
>  Fix: have handleEvent fetch the default App Store catalog before comparing (in addition to any custom sites), so the cache is populated when checkForUpdates runs. Verified in the isolated clone — updates.size()=1, count=1, 
  setEnabled(true), and the red "1" badge appeared.

tried this out on desktop locally and was able to see the bell get notified:

<img width="1332" height="624" alt="Screenshot 2026-07-10 at 4 15 31 PM" src="https://github.com/user-attachments/assets/586b37e6-c7d8-4774-bcc9-6cd2eac315d4" />

Also added new github CI unit test run step.

I'm not sure which branch to target, this is based on 3.10.4 and is best as a hotfix onto that line.

Closes: cytoscape/cytoscape#27