### PR TITLE
cytoscape/cytoscape#35: Move source:aggregate into a 'sources' profile, use HTTPS repos

### DIFF
--- a/.travis.settings.xml
+++ b/.travis.settings.xml
@@ -32,7 +32,7 @@
             <enabled>false</enabled>
           </releases>
           <name>Cytoscape Snapshots</name>
-          <url>http://nrnb-nexus.ucsd.edu/repository/cytoscape_snapshots/</url>
+          <url>https://nrnb-nexus.ucsd.edu/repository/cytoscape_snapshots/</url>
         </repository>
         <repository>
           <id>cytoscape_releases</id>
@@ -43,7 +43,7 @@
             <enabled>true</enabled>
           </releases>
           <name>Cytoscape Releases</name>
-          <url>http://nrnb-nexus.ucsd.edu/repository/cytoscape_releases/</url>
+          <url>https://nrnb-nexus.ucsd.edu/repository/cytoscape_releases/</url>
         </repository>
         <repository>
           <id>cytoscape_thirdparty</id>
@@ -54,12 +54,12 @@
             <enabled>true</enabled>
           </releases>
           <name>Cytoscape Third Party</name>
-          <url>http://nrnb-nexus.ucsd.edu/repository/cytoscape_thirdparty/</url>
+          <url>https://nrnb-nexus.ucsd.edu/repository/cytoscape_thirdparty/</url>
         </repository>
         <repository>
           <id>central</id>
           <name>Central Repository</name>
-          <url>http://repo.maven.apache.org/maven2</url>
+          <url>https://repo.maven.apache.org/maven2</url>
           <releases>
             <enabled>true</enabled>
           </releases>

--- a/pom.xml
+++ b/pom.xml
@@ -394,24 +394,49 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
-
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-				<version>${maven-source-plugin.version}</version>
-				<executions>
-					<execution>
-						<id>aggregate-source</id>
-						<phase>package</phase>
-						<goals>
-							<goal>aggregate</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
 	</build>
+
+	<!--
+		The 'sources' profile builds the aggregated sources JAR that the
+		app-developer distribution ships (org.cytoscape:impl-parent:jar:sources).
+
+		It is deliberately kept out of the default build.  source:aggregate is an
+		aggregator goal: it forks a generate-sources lifecycle over every module
+		below, and a forked lifecycle resolves its dependencies from the local
+		repository instead of the reactor.  Running at impl-parent - module 33 of
+		the reactor - it looks for impl artifacts the reactor has not built yet,
+		so a build from a cold repository dies there.  Note that
+		-Dmaven.source.skip=true does not help: the fork is planned before the
+		skip flag is evaluated.  See cytoscape/cytoscape#35.
+
+		Run it as a second pass, after a normal build has populated ~/.m2:
+
+		    mvn clean install -DskipTests
+		    mvn install -Psources -DskipTests
+	-->
+	<profiles>
+		<profile>
+			<id>sources</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-source-plugin</artifactId>
+						<version>${maven-source-plugin.version}</version>
+						<executions>
+							<execution>
+								<id>aggregate-source</id>
+								<phase>package</phase>
+								<goals>
+									<goal>aggregate</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 
 	<scm>
 		<connection>scm:git:git://github.com/cytoscape/cytoscape-impl.git</connection>

--- a/table-import-impl/pom.xml
+++ b/table-import-impl/pom.xml
@@ -81,18 +81,6 @@
 			<name>Cytoscape Third Party</name>
 			<url>https://nrnb-nexus.ucsd.edu/repository/cytoscape_thirdparty/</url>
 		</repository>
-		
-		<repository>
-  			<id>com.springsource.repository.bundles.release</id>
-    		<name>SpringSource Enterprise Bundle Repository - SpringSource Bundle Releases</name>
-    		<url>http://repository.springsource.com/maven/bundles/release</url>
-		</repository>
-
-		<repository>
-    		<id>com.springsource.repository.bundles.external</id>
-    		<name>SpringSource Enterprise Bundle Repository - External Bundle Releases</name>
-    		<url>http://repository.springsource.com/maven/bundles/external</url>
-		</repository>		
 	</repositories>
 
 	<dependencies>


### PR DESCRIPTION
Part of the multi-repository fix for cytoscape/cytoscape#35. Main description and full verification: **cytoscape/cytoscape#36**.

> ⚠️ **Must merge together with cytoscape/cytoscape-api and cytoscape/cytoscape-app-developer.**

## Changes

**Move `source:aggregate` into a `sources` profile.** `impl/pom.xml` bound maven-source-plugin's `aggregate` goal to the `package` phase of `impl-parent`. That goal forks a `generate-sources` lifecycle over every module, and a forked lifecycle resolves dependencies from the local repository rather than the reactor — so at `impl-parent`, module 33 of 122, it looked for impl artifacts the reactor had not built yet. With 130 intra-`impl` dependency edges this fails on any build whose version is not already in `~/.m2`. `api` had the same problem earlier in the reactor.

Not a circular dependency: the module graph is acyclic. Also note `-Dmaven.source.skip=true` does not help — the fork is planned before the skip flag is evaluated.

The aggregated sources JAR is still needed by the app-developer kit, so it moves to a `sources` profile used as a second pass:

```sh
mvn clean install -DskipTests
mvn install -Psources -DskipTests
```

**Use HTTPS for Maven repositories** in `.travis.settings.xml`; Maven 3.8.1+ blocks plain http. Repository ids are unchanged.

**Drop the dead SpringSource repositories** from `table-import-impl`. `repository.springsource.com` no longer resolves over http *or* https, so those two declarations could only slow resolution down. The module's dependencies resolve from Central and the Cytoscape nexus.

## Note for reviewers

`impl/.mvn/settings.xml` still defines a dummy mirror with the id `maven-default-http-blocker`, which neutralises Maven's http blocking for builds run from this directory (added in 40927ef9b for the CI workflow in cytoscape/cytoscape#27). With these URLs on https it should no longer be needed, but it is left alone here so that change can be revisited on its own.

## Verification

Verified as part of the full seven-repository build on `develop` against a genuinely empty local repository with no settings file: 122 SUCCESS / 0 FAILURE on both passes, zero blocked-mirror errors. Details in cytoscape/cytoscape#36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Updated Maven repository connections to use secure HTTPS URLs.
  * Moved source aggregation into an optional build profile, allowing standard builds to complete independently.
  * Removed obsolete repository configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->